### PR TITLE
Implement `getLatestTweet()` in tweets.ts

### DIFF
--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -10,7 +10,7 @@ import {
 } from './search';
 import { QueryProfilesResponse, QueryTweetsResponse } from './timeline';
 import { getTrends } from './trends';
-import { getTweet, getTweets, Tweet } from './tweets';
+import { getTweet, getTweets, getLatestTweet, Tweet } from './tweets';
 
 /**
  * An interface to Twitter's undocumented API.
@@ -147,6 +147,21 @@ export class Scraper {
     includeReplies: boolean,
   ): AsyncGenerator<Tweet> {
     return getTweets(user, maxTweets, includeReplies, this.auth);
+  }
+
+  /**
+   * Fetches the most recent tweet from a Twitter user.
+   * @param user The user whose latest tweet should be returned.
+   * @param includeReplies Whether or not to include tweet replies.
+   * @param includeRetweets Whether or not to include retweets.
+   * @returns The {@link Tweet} object or `null` if it couldn't be fetched.
+   */
+  public getLatestTweet(
+    user: string,
+    includeReplies: boolean,
+    includeRetweets: boolean,
+  ): Promise<Tweet | null> {
+    return getLatestTweet(user, includeReplies, includeRetweets, this.auth);
   }
 
   /**

--- a/src/tweets.test.ts
+++ b/src/tweets.test.ts
@@ -34,6 +34,19 @@ test('scraper can get tweet', async () => {
   expect(expected).toEqual(actual);
 });
 
+test('scraper can get latest tweet', async () => {
+  const scraper = new Scraper();
+
+  // OLD APPROACH (without retweet filtering)
+  const tweets = scraper.getTweets('elonmusk', 1, false);
+  const expected = (await tweets.next()).value;
+
+  // NEW APPROACH
+  const latest = await scraper.getLatestTweet('elonmusk', false, expected.isRetweet);
+
+  expect(expected.permanentUrl).toEqual(latest?.permanentUrl);
+});
+
 test('scraper can get tweet quotes and replies', async () => {
   const expected: Tweet = {
     html: `The Easiest Problem Everyone Gets Wrong <br><br>[new video] --&gt; <a href=\"https://youtu.be/ytfCdqWhmdg\">https://t.co/YdaeDYmPAU</a> <br><a href=\"https://t.co/iKu4Xs6o2V\"><img src=\"https://pbs.twimg.com/media/ESsZa9AXgAIAYnF.jpg\"/></a>`,

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -102,6 +102,28 @@ export function getTweets(
   });
 }
 
+export async function getLatestTweet(
+  user: string,
+  includeReplies: boolean,
+  includeRetweets: boolean,
+  auth: TwitterGuestAuth,
+): Promise<Tweet | null> {
+  const max = includeRetweets ? 1 : 200;
+  const timeline = await getTweets(user, max, includeReplies, auth);
+
+  if (max == 1) {
+    return (await timeline.next()).value;
+  }
+
+  for await (const tweet of timeline) {
+    if (!tweet.isRetweet) {
+      return tweet;
+    }
+  }
+
+  return null;
+}
+
 export async function getTweet(
   id: string,
   includeReplies: boolean,


### PR DESCRIPTION
Just a small pull that adds an easier way to get the latest tweet, with an `includeRetweets` parameter included.
I have tested it on my end via Jest and can confirm it works.

```ts
test('scraper can get latest tweet', async () => {
  const scraper = new Scraper();
  
  // OLD APPROACH (without retweet filtering)
  const tweets = scraper.getTweets('elonmusk', 1, false);
  const expected = (await tweets.next()).value;
  
  // NEW APPROACH
  const latest = await scraper.getLatestTweet('elonmusk', false, false);
  
  expect(expected.permanentUrl).toEqual(latest?.permanentUrl);
});
```