### PR TITLE
Documentation improvements.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc",
     "commit": "cz",
-    "docs:generate": "typedoc --entryPoints src --entryPointStrategy expand --exclude **/*.test.ts",
+    "docs:generate": "typedoc --options typedoc.json",
     "docs:deploy": "yarn docs:generate && gh-pages -d docs",
     "format": "prettier --write \\\"src/**/*.ts\\\" \\\"test/**/*.ts\\\"",
     "prepare": "husky install",

--- a/src/api.ts
+++ b/src/api.ts
@@ -16,6 +16,14 @@ export type RequestApiResult<T> =
   | { success: true; value: T }
   | { success: false; err: Error };
 
+/**
+ * Used internally to send HTTP requests to the Twitter API.
+ * @internal
+ * 
+ * @param url - The URL to send the request to.
+ * @param auth - The instance of {@link TwitterAuth} that will be used to authorize this request.
+ * @param method - The HTTP method used when sending this request.
+ */
 export async function requestApi<T>(
   url: string,
   auth: TwitterAuth,

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -24,15 +24,16 @@ const twUrl = 'https://twitter.com';
 
 /**
  * An interface to Twitter's undocumented API.
- * Reusing Scraper objects is recommended to minimize the time spent authenticating unnecessarily.
+ * - Reusing Scraper objects is recommended to minimize the time spent authenticating unnecessarily.
  */
 export class Scraper {
   private auth: TwitterAuth;
   private authTrends: TwitterAuth;
 
   /**
-   * Creates a new Scraper object. Scrapers maintain their own guest tokens for Twitter's internal API.
-   * Reusing Scraper objects is recommended to minimize the time spent authenticating unnecessarily.
+   * Creates a new Scraper object. 
+   * - Scrapers maintain their own guest tokens for Twitter's internal API.
+   * - Reusing Scraper objects is recommended to minimize the time spent authenticating unnecessarily.
    */
   constructor() {
     this.auth = new TwitterGuestAuth(bearerToken);
@@ -42,7 +43,7 @@ export class Scraper {
   /**
    * Fetches a Twitter profile.
    * @param username The Twitter username of the profile to fetch, without an `@` at the beginning.
-   * @returns The requested profile.
+   * @returns The requested {@link Profile}. 
    */
   public async getProfile(username: string): Promise<Profile> {
     const res = await getProfile(username, this.auth);
@@ -65,7 +66,7 @@ export class Scraper {
    * @param maxTweets The maximum number of tweets to return.
    * @param includeReplies Whether or not replies should be included in the response.
    * @param searchMode The category filter to apply to the search. Defaults to `Top`.
-   * @returns An async generator of tweets matching the provided filters.
+   * @returns An {@link AsyncGenerator} of tweets matching the provided filters.
    */
   public searchTweets(
     query: string,
@@ -79,7 +80,7 @@ export class Scraper {
    * Fetches profiles from Twitter.
    * @param query The search query. Any Twitter-compatible query format can be used.
    * @param maxProfiles The maximum number of profiles to return.
-   * @returns An async generator of tweets matching the provided filters.
+   * @returns An {@link AsyncGenerator} of tweets matching the provided filter(s).
    */
   public searchProfiles(
     query: string,
@@ -132,25 +133,22 @@ export class Scraper {
   /**
    * Fetches tweets from a Twitter user.
    * @param user The user whose tweets should be returned.
-   * @param maxTweets The maximum number of tweets to return.
-   * @returns An async generator of tweets from the provided user.
+   * @param maxTweets The maximum number of tweets to return. Defaults to `200`.
+   * @returns An {@link AsyncGenerator} of tweets from the provided user.
    */
-  public getTweets(
-    user: string,
-    maxTweets: number,
-  ): AsyncGenerator<Tweet, void> {
+  public getTweets(user: string, maxTweets = 200): AsyncGenerator<Tweet> {
     return getTweets(user, maxTweets, this.auth);
   }
 
   /**
    * Fetches tweets from a Twitter user using their ID.
    * @param userId The user whose tweets should be returned.
-   * @param maxTweets The maximum number of tweets to return.
-   * @returns An async generator of tweets from the provided user.
+   * @param maxTweets The maximum number of tweets to return. Defaults to `200`.
+   * @returns An {@link AsyncGenerator} of tweets from the provided user.
    */
   public getTweetsByUserId(
     userId: string,
-    maxTweets: number,
+    maxTweets = 200,
   ): AsyncGenerator<Tweet, void> {
     return getTweetsByUserId(userId, maxTweets, this.auth);
   }
@@ -158,12 +156,12 @@ export class Scraper {
   /**
    * Fetches the most recent tweet from a Twitter user.
    * @param user The user whose latest tweet should be returned.
-   * @param includeRetweets Whether or not to include retweets.
+   * @param includeRetweets Whether or not to include retweets. Defaults to `false`.
    * @returns The {@link Tweet} object or `null`/`undefined` if it couldn't be fetched.
    */
   public getLatestTweet(
     user: string,
-    includeRetweets: boolean,
+    includeRetweets = false,
   ): Promise<Tweet | null | void> {
     return getLatestTweet(user, includeRetweets, this.auth);
   }
@@ -171,7 +169,7 @@ export class Scraper {
   /**
    * Fetches a single tweet.
    * @param id The ID of the tweet to fetch.
-   * @returns The request tweet, or `null` if it couldn't be fetched.
+   * @returns The {@link Tweet} object, or `null` if it couldn't be fetched.
    */
   public getTweet(id: string): Promise<Tweet | null> {
     return getTweet(id, this.auth);

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,6 @@
+{
+    "entryPointStrategy": "expand",
+    "entryPoints": ["src"],
+    "exclude": ["**/*.test.ts", "**/_*.ts"],
+    "cleanOutputDir": true
+}


### PR DESCRIPTION
- use `typedoc.json` to build docs instead of a long script.
- slight documentation edits inside "scraper.ts" file.
- document `requestApi` method, including internal tag.
- exclude files beginning with an underscore from documentation, this will remove `_module.html` which only contains 404s.