### PR TITLE
fix: jest auth and methods returning no tweet(s).

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+/** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFiles: ['dotenv/config']
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.7",
     "@typescript-eslint/parser": "^5.59.7",
     "cz-conventional-changelog": "^3.3.0",
+    "dotenv": "^16.3.1",
     "eslint": "^8.41.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -4,9 +4,9 @@ export async function authSearchScraper() {
   const username = process.env['TWITTER_USERNAME'];
   const password = process.env['TWITTER_PASSWORD'];
   const email = process.env['TWITTER_EMAIL'];
-  if (!username || !password || !email) {
+  if (!username || !password) {
     throw new Error(
-      'TWITTER_USERNAME, TWITTER_PASSWORD, and TWITTER_EMAIL variables must be defined.',
+      'TWITTER_USERNAME and TWITTER_PASSWORD variables must be defined.',
     );
   }
 

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -241,7 +241,7 @@ export function parseTimelineTweetsV2(
     }
   }
 
-  return { tweets: [], next: cursor };
+  return { tweets, next: cursor };
 }
 
 export function parseThreadedConversation(


### PR DESCRIPTION
- fixed `fetchTweets` returning an empty array lol :]
- remove deprecation warning by using `JestConfigWithTsJest`
- allow jest to use local .env file by providing `dotenv` to config.
- make email variable optional when running auth test.