### PR TITLE
fix: update bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A port of [n0madic/twitter-scraper](https://github.com/n0madic/twitter-scraper) 
 
 Known limitations:
 
-* All operations now require logging in with a real user account (see [original README](https://github.com/n0madic/twitter-scraper#authentication))
+* Search operations require logging in with a real user account via `scraper.login()`.
 * Twitter's frontend API does in fact have rate limits ([#11](https://github.com/the-convocation/twitter-scraper/issues/11))
 
 ## Installation

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,9 +5,7 @@ import { Headers } from 'headers-polyfill';
 import fetch from 'cross-fetch';
 
 export const bearerToken =
-  'AAAAAAAAAAAAAAAAAAAAAPYXBAAAAAAACLXUNDekMxqa8h%2F40K4moUkGsoc%3DTYfbDKbT3jJPCEVnMYqilB28NHfOPqkca3qaAxGfsyKCs0wRbw';
-export const bearerToken2 =
-  'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
+  'AAAAAAAAAAAAAAAAAAAAAFQODgEAAAAAVHTp76lzh3rFzcHbmHVvQxYYpTw%3DckAlMINMjmCwxUcaXbAN4XqJVdgMJaHqNOFgPMK0zN1qLqLQCF';
 
 /**
  * An API result container.
@@ -87,6 +85,9 @@ export async function requestApi<T>(
   }
 }
 
+/**
+ * @internal
+ */
 export function addApiFeatures(o: object) {
   return {
     ...o,

--- a/src/tweets.test.ts
+++ b/src/tweets.test.ts
@@ -1,4 +1,5 @@
 import { authSearchScraper } from './auth.test';
+import { Scraper } from './scraper';
 import { Mention, Tweet } from './tweets';
 
 test('scraper can get tweet', async () => {
@@ -37,19 +38,32 @@ test('scraper can get tweet', async () => {
   expect(expected).toEqual(actual);
 });
 
+test('scraper can tweets without logging in', async () => {
+  const scraper = new Scraper();
+
+  const sampleSize = 5;
+  const tweets = scraper.getTweets('elonmusk', sampleSize);
+
+  let counter = 0;
+  for await (const tweet of tweets) {
+    if (tweet?.permanentUrl) {
+      counter++;
+    }
+  }
+
+  expect(counter).toBe(sampleSize);
+});
+
 test('scraper can get latest tweet', async () => {
-  const scraper = await authSearchScraper();
+  const scraper = new Scraper();
 
   // OLD APPROACH (without retweet filtering)
   const tweets = scraper.getTweets('elonmusk', 1);
   const expected = (await tweets.next()).value;
 
   // NEW APPROACH
-  const latest = await scraper.getLatestTweet(
-    'elonmusk',
-    expected?.isRetweet ? true : false,
-  );
-
+  const includeRts = expected?.isRetweet || false;
+  const latest = await scraper.getLatestTweet('elonmusk', includeRts);
   expect(expected?.permanentUrl).toEqual(latest?.permanentUrl);
 });
 

--- a/src/tweets.test.ts
+++ b/src/tweets.test.ts
@@ -38,7 +38,7 @@ test('scraper can get tweet', async () => {
   expect(expected).toEqual(actual);
 });
 
-test('scraper can tweets without logging in', async () => {
+test('scraper can get tweets without logging in', async () => {
   const scraper = new Scraper();
 
   const sampleSize = 5;

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,5 +2,5 @@
     "entryPointStrategy": "expand",
     "entryPoints": ["src"],
     "exclude": ["**/*.test.ts", "**/_*.ts"],
-    "cleanOutputDir": true
+    "hideGenerator": true
 }


### PR DESCRIPTION
Heyo, me again 👋🏼 

- removed both tokens in favour of new, updated one used by nitter.
- implemented cleaner `useGuestAuth` method used by both constructor and `logout`.
- created a new test to ensure tweets are fetched without logging in.
- running latest tweet test now uses regular scraper instead of `authSearchScraper`.

**Note**:
Nitter also changed some features and graphql endpoints, but I'm not familiar with them so they were not included.
See [this commit](https://github.com/zedeus/nitter/pull/927/commits/d1f80446ef9c3c78b41572382d34812eb5131b27#diff-5191c99e8da841954d23cae0097143d48f54b50737f8ef7b8b7ef2fabdd2dcd6)