### PR TITLE
fix some Tweet properties defaulting to undefined.

### DIFF
--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -127,6 +127,11 @@ export function parseLegacyTweet(
     userId: tweet.user_id_str,
     username: user.screen_name,
     videos,
+    isQuoted: false,
+    isReply: false,
+    isRetweet: false,
+    isPin: false,
+    sensitiveContent: false,
   };
 
   if (tweet.created_at) {
@@ -138,27 +143,33 @@ export function parseLegacyTweet(
     tw.place = tweet.place;
   }
 
-  if (tweet.quoted_status_id_str) {
+  const quotedStatusIdStr = tweet.quoted_status_id_str;
+  const inReplyToStatusIdStr = tweet.in_reply_to_status_id_str;
+  const retweetedStatusIdStr = tweet.retweeted_status_id_str;
+  const retweetedStatusResult = tweet.retweeted_status_result?.result;
+
+  if (quotedStatusIdStr) {
     tw.isQuoted = true;
-    tw.quotedStatusId = tweet.quoted_status_id_str;
+    tw.quotedStatusId = quotedStatusIdStr;
   }
 
-  if (tweet.in_reply_to_status_id_str) {
+  if (inReplyToStatusIdStr) {
     tw.isReply = true;
-    tw.inReplyToStatusId = tweet.in_reply_to_status_id_str;
+    tw.inReplyToStatusId = inReplyToStatusIdStr;
   }
 
-  if (tweet.retweeted_status_id_str || tweet.retweeted_status_result?.result) {
+  if (retweetedStatusIdStr || retweetedStatusResult) {
     tw.isRetweet = true;
-    tw.retweetedStatusId = tweet.retweeted_status_id_str;
+    tw.retweetedStatusId = retweetedStatusIdStr;
 
-    if (tweet.retweeted_status_result?.result) {
-      const retweetedStatusResult = parseLegacyTweet(
-        tweet.retweeted_status_result.result.core?.user_results?.result?.legacy,
-        tweet.retweeted_status_result.result.legacy,
+    if (retweetedStatusResult) {
+      const parsedResult = parseLegacyTweet(
+        retweetedStatusResult?.core?.user_results?.result?.legacy,
+        retweetedStatusResult?.legacy,
       );
-      if (retweetedStatusResult.success) {
-        tw.retweetedStatus = retweetedStatusResult.tweet;
+
+      if (parsedResult.success) {
+        tw.retweetedStatus = parsedResult.tweet;
       }
     }
   }

--- a/src/tweets.test.ts
+++ b/src/tweets.test.ts
@@ -26,6 +26,11 @@ test('scraper can get tweet', async () => {
         url: 'https://video.twimg.com/amplify_video/1328684333599756289/vid/960x720/PcL8yv8KhgQ48Qpt.mp4?tag=13',
       },
     ],
+    isQuoted: false,
+    isReply: false,
+    isRetweet: false,
+    isPin: false,
+    sensitiveContent: false,
   };
 
   const scraper = new Scraper();
@@ -61,10 +66,13 @@ test('scraper can get latest tweet', async () => {
   const expected = (await tweets.next()).value;
 
   // NEW APPROACH
-  const includeRts = expected?.isRetweet || false;
-  const latest = await scraper.getLatestTweet('elonmusk', includeRts);
+  const latest = (await scraper.getLatestTweet(
+    'elonmusk',
+    expected?.isRetweet || false,
+  )) as Tweet;
+
   expect(expected?.permanentUrl).toEqual(latest?.permanentUrl);
-});
+}, 30000);
 
 test('scraper can get user mentions in tweets', async () => {
   const expected: Mention[] = [
@@ -103,6 +111,11 @@ test('scraper can get tweet quotes and replies', async () => {
     userId: '978944851',
     username: 'VsauceTwo',
     videos: [],
+    isQuoted: false,
+    isReply: false,
+    isRetweet: false,
+    isPin: false,
+    sensitiveContent: false,
   };
 
   const scraper = new Scraper();
@@ -145,6 +158,11 @@ test('scraper can get retweet', async () => {
     userId: '773578328498372608',
     username: 'TwitterTogether',
     videos: [],
+    isQuoted: false,
+    isReply: false,
+    isRetweet: false,
+    isPin: false,
+    sensitiveContent: false,
   };
 
   const scraper = new Scraper();
@@ -176,6 +194,11 @@ test('scraper can get tweet views', async () => {
     userId: '17874544',
     username: 'TwitterSupport',
     videos: [],
+    isQuoted: false,
+    isReply: false,
+    isRetweet: false,
+    isPin: false,
+    sensitiveContent: false,
   };
 
   const scraper = new Scraper();


### PR DESCRIPTION
The following properties on the `Tweet` interface are now `false` as default. 
This most likely fixes any methods that caused issues as a result of checking any of these.

- `isQuoted`
- `isRetweet`
- `isReply`
- `isPin`
- `sensitiveContent`

Tweet tests have been updated accordingly.