### PR TITLE
feat: utility methods for fetching tweets using a query

### DIFF
--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -13,11 +13,12 @@ import {
 import { QueryProfilesResponse, QueryTweetsResponse } from './timeline-v1';
 import { getTrends } from './trends';
 import {
+  Tweet,
   getTweet,
   getTweets,
   getLatestTweet,
-  getTweetWhere,
-  Tweet,
+  getTweetsWhere,
+  TweetMatchOptions,
   getTweetsByUserId,
 } from './tweets';
 import fetch from 'cross-fetch';
@@ -181,23 +182,22 @@ export class Scraper {
   }
 
   /**
-   * Utility function for fetching the first tweet where `key` matches `value`.
+   * Utility function for fetching the all tweets matching the given query.
    *
    * Example:
    * ```js
    * const timeline = getTweets("user", 200)
-   * const tweet = await getTweetWhere('isQuoted', true, timeline);
+   * const retweets = await getTweetsWhere({ isRetweet: true }, timeline);
    * ```
    * @param key An existing key on the {@link Tweet} interface.
    * @param value The value that the key is expected to match.
    * @param tweets The {@link AsyncGenerator} of tweets to search through.
    */
-  public getTweetWhere(
-    key: string,
-    value: any,
+  public getTweetsWhere(
+    query: TweetMatchOptions,
     tweets: AsyncGenerator<Tweet, void>,
-  ): Promise<Tweet | null> {
-    return getTweetWhere(key, value, tweets);
+  ): Promise<Tweet[]> {
+    return getTweetsWhere(query, tweets);
   }
 
   /**

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -199,7 +199,7 @@ export class Scraper {
     tweets: AsyncIterable<Tweet>,
     query: TweetQuery,
   ): Promise<Tweet | null> {
-    return getTweetWhere(query, tweets);
+    return getTweetWhere(tweets, query);
   }
 
   /**
@@ -219,7 +219,7 @@ export class Scraper {
     tweets: AsyncIterable<Tweet>,
     query: TweetQuery,
   ): Promise<Tweet[]> {
-    return getTweetsWhere(query, tweets);
+    return getTweetsWhere(tweets, query);
   }
 
   /**

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -19,8 +19,8 @@ import {
   getLatestTweet,
   getTweetWhere,
   getTweetsWhere,
-  TweetMatchOptions,
   getTweetsByUserId,
+  TweetQuery,
 } from './tweets';
 import fetch from 'cross-fetch';
 
@@ -196,8 +196,8 @@ export class Scraper {
    * @param tweets The {@link AsyncGenerator} of tweets to search through.
    */
   public getTweetWhere(
-    query: TweetMatchOptions,
-    tweets: AsyncGenerator<Tweet, void> | Tweet[],
+    query: TweetQuery,
+    tweets: AsyncIterable<Tweet>,
   ): Promise<Tweet | null> {
     return getTweetWhere(query, tweets);
   }
@@ -216,8 +216,8 @@ export class Scraper {
    * @param tweets The {@link AsyncGenerator} of tweets to search through.
    */
   public getTweetsWhere(
-    query: TweetMatchOptions,
-    tweets: AsyncGenerator<Tweet, void> | Tweet[],
+    query: TweetQuery,
+    tweets: AsyncIterable<Tweet>,
   ): Promise<Tweet[]> {
     return getTweetsWhere(query, tweets);
   }

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -196,8 +196,8 @@ export class Scraper {
    * @param tweets The {@link AsyncGenerator} of tweets to search through.
    */
   public getTweetWhere(
-    query: TweetQuery,
     tweets: AsyncIterable<Tweet>,
+    query: TweetQuery,
   ): Promise<Tweet | null> {
     return getTweetWhere(query, tweets);
   }
@@ -216,8 +216,8 @@ export class Scraper {
    * @param tweets The {@link AsyncGenerator} of tweets to search through.
    */
   public getTweetsWhere(
-    query: TweetQuery,
     tweets: AsyncIterable<Tweet>,
+    query: TweetQuery,
   ): Promise<Tweet[]> {
     return getTweetsWhere(query, tweets);
   }

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -17,6 +17,7 @@ import {
   getTweet,
   getTweets,
   getLatestTweet,
+  getTweetWhere,
   getTweetsWhere,
   TweetMatchOptions,
   getTweetsByUserId,
@@ -182,15 +183,36 @@ export class Scraper {
   }
 
   /**
-   * Utility function for fetching the all tweets matching the given query.
+   * Fetches the first tweet matching the given query.
    *
    * Example:
    * ```js
    * const timeline = getTweets("user", 200)
    * const retweets = await getTweetsWhere({ isRetweet: true }, timeline);
    * ```
-   * @param key An existing key on the {@link Tweet} interface.
-   * @param value The value that the key is expected to match.
+   * @param query A set of key/value pairs to test **all** tweets against.
+   * - All keys are optional.
+   * - If specified, the key must be implemented by that of {@link Tweet}.
+   * @param tweets The {@link AsyncGenerator} of tweets to search through.
+   */
+  public getTweetWhere(
+    query: TweetMatchOptions,
+    tweets: AsyncGenerator<Tweet, void>,
+  ): Promise<Tweet | null> {
+    return getTweetWhere(query, tweets);
+  }
+
+  /**
+   * Fetches all tweets matching the given query.
+   *
+   * Example:
+   * ```js
+   * const timeline = getTweets("user", 200)
+   * const retweets = await getTweetsWhere({ isRetweet: true }, timeline);
+   * ```
+   * @param query A set of key/value pairs to test **all** tweets against.
+   * - All keys are optional.
+   * - If specified, the key must be implemented by that of {@link Tweet}.
    * @param tweets The {@link AsyncGenerator} of tweets to search through.
    */
   public getTweetsWhere(

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -16,6 +16,7 @@ import {
   getTweet,
   getTweets,
   getLatestTweet,
+  getTweetWhere,
   Tweet,
   getTweetsByUserId,
 } from './tweets';
@@ -180,6 +181,26 @@ export class Scraper {
   }
 
   /**
+   * Utility function for fetching the first tweet where `key` matches `value`.
+   *
+   * Example:
+   * ```js
+   * const timeline = getTweets("user", 200)
+   * const tweet = await getTweetWhere('isQuoted', true, timeline);
+   * ```
+   * @param key An existing key on the {@link Tweet} interface.
+   * @param value The value that the key is expected to match.
+   * @param tweets The {@link AsyncGenerator} of tweets to search through.
+   */
+  public getTweetWhere(
+    key: string,
+    value: any,
+    tweets: AsyncGenerator<Tweet, void>,
+  ): Promise<Tweet | null> {
+    return getTweetWhere(key, value, tweets);
+  }
+
+  /**
    * Fetches the most recent tweet from a Twitter user.
    * @param user The user whose latest tweet should be returned.
    * @param includeRetweets Whether or not to include retweets. Defaults to `false`.
@@ -188,8 +209,9 @@ export class Scraper {
   public getLatestTweet(
     user: string,
     includeRetweets = false,
+    max = 200,
   ): Promise<Tweet | null | void> {
-    return getLatestTweet(user, includeRetweets, this.auth);
+    return getLatestTweet(user, includeRetweets, max, this.auth);
   }
 
   /**

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -197,7 +197,7 @@ export class Scraper {
    */
   public getTweetWhere(
     query: TweetMatchOptions,
-    tweets: AsyncGenerator<Tweet, void>,
+    tweets: AsyncGenerator<Tweet, void> | Tweet[],
   ): Promise<Tweet | null> {
     return getTweetWhere(query, tweets);
   }
@@ -217,7 +217,7 @@ export class Scraper {
    */
   public getTweetsWhere(
     query: TweetMatchOptions,
-    tweets: AsyncGenerator<Tweet, void>,
+    tweets: AsyncGenerator<Tweet, void> | Tweet[],
   ): Promise<Tweet[]> {
     return getTweetsWhere(query, tweets);
   }

--- a/src/tweets.test.ts
+++ b/src/tweets.test.ts
@@ -58,6 +58,18 @@ test('scraper can get tweets without logging in', async () => {
   expect(counter).toBe(sampleSize);
 });
 
+test('scraper can get only matching tweets', async () => {
+  const scraper = new Scraper();
+  const timeline = scraper.getTweets('elonmusk', 20);
+
+  const retweets = await scraper.getTweetsWhere({ isRetweet: true }, timeline);
+  expect(retweets).toBeTruthy();
+
+  for (const tweet of retweets) {
+    expect(tweet.isRetweet).toBe(true);
+  }
+}, 20000);
+
 test('scraper can get latest tweet', async () => {
   const scraper = new Scraper();
 

--- a/src/tweets.test.ts
+++ b/src/tweets.test.ts
@@ -62,7 +62,7 @@ test('scraper can get first tweet matching query', async () => {
   const scraper = new Scraper();
 
   const timeline = scraper.getTweets('elonmusk');
-  const latestQuote = await scraper.getTweetWhere({ isQuoted: true }, timeline);
+  const latestQuote = await scraper.getTweetWhere(timeline, { isQuoted: true });
 
   expect(latestQuote?.isQuoted).toBeTruthy();
 });
@@ -73,8 +73,8 @@ test('scraper can get all tweets matching query', async () => {
   // Sample size of 20 should be enough without taking long.
   const timeline = scraper.getTweets('elonmusk', 20);
   const retweets = await scraper.getTweetsWhere(
-    (tweet) => tweet.isRetweet === true,
     timeline,
+    (tweet) => tweet.isRetweet === true,
   );
 
   expect(retweets).toBeTruthy();

--- a/src/tweets.test.ts
+++ b/src/tweets.test.ts
@@ -58,10 +58,20 @@ test('scraper can get tweets without logging in', async () => {
   expect(counter).toBe(sampleSize);
 });
 
-test('scraper can get only matching tweets', async () => {
+test('scraper can get first tweet matching query', async () => {
   const scraper = new Scraper();
-  const timeline = scraper.getTweets('elonmusk', 20);
 
+  const timeline = scraper.getTweets('elonmusk');
+  const latestQuote = await scraper.getTweetWhere({ isQuoted: true }, timeline);
+
+  expect(latestQuote?.isQuoted).toBeTruthy();
+});
+
+test('scraper can get all tweets matching query', async () => {
+  const scraper = new Scraper();
+
+  // Sample size of 20 should be enough without taking long.
+  const timeline = scraper.getTweets('elonmusk', 20);
   const retweets = await scraper.getTweetsWhere({ isRetweet: true }, timeline);
   expect(retweets).toBeTruthy();
 

--- a/src/tweets.test.ts
+++ b/src/tweets.test.ts
@@ -72,7 +72,11 @@ test('scraper can get all tweets matching query', async () => {
 
   // Sample size of 20 should be enough without taking long.
   const timeline = scraper.getTweets('elonmusk', 20);
-  const retweets = await scraper.getTweetsWhere({ isRetweet: true }, timeline);
+  const retweets = await scraper.getTweetsWhere(
+    (tweet) => tweet.isRetweet === true,
+    timeline,
+  );
+
   expect(retweets).toBeTruthy();
 
   for (const tweet of retweets) {

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -210,7 +210,7 @@ export async function getLatestTweet(
   // No point looping if max is 1, just use first entry.
   return max === 1
     ? (await timeline.next()).value
-    : await getTweetWhere({ isRetweet: includeRetweets }, timeline);
+    : await getTweetWhere(timeline, { isRetweet: includeRetweets });
 }
 
 export async function getTweet(

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -158,7 +158,7 @@ export function getTweetsByUserId(
 
 export async function getTweetWhere(
   options: TweetMatchOptions,
-  tweets: AsyncGenerator<Tweet>,
+  tweets: AsyncGenerator<Tweet> | Tweet[],
 ): Promise<Tweet | null> {
   for await (const tweet of tweets) {
     const matches = Object.keys(options).every((k) => {
@@ -176,7 +176,7 @@ export async function getTweetWhere(
 
 export async function getTweetsWhere(
   options: TweetMatchOptions,
-  tweets: AsyncGenerator<Tweet>,
+  tweets: AsyncGenerator<Tweet> | Tweet[],
 ): Promise<Tweet[]> {
   const filtered = [];
 

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -80,6 +80,8 @@ export interface Tweet {
   sensitiveContent?: boolean;
 }
 
+export type TweetMatchOptions = Partial<Tweet>;
+
 export async function fetchTweets(
   userId: string,
   maxTweets: number,
@@ -154,18 +156,23 @@ export function getTweetsByUserId(
   });
 }
 
-export async function getTweetWhere(
-  key: string,
-  val: boolean,
+export async function getTweetsWhere(
+  options: TweetMatchOptions,
   tweets: AsyncGenerator<Tweet>,
-) {
+): Promise<Tweet[]> {
+  const filtered = [];
+
   for await (const tweet of tweets) {
-    if (tweet[key as keyof Tweet] == val) {
-      return tweet;
-    }
+    const matches = Object.keys(options).every((k) => {
+      const key = k as keyof Tweet;
+      return tweet[key] == options[key];
+    });
+
+    if (!matches) continue;
+    filtered.push(tweet);
   }
 
-  return null;
+  return filtered;
 }
 
 export async function getLatestTweet(

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -156,6 +156,24 @@ export function getTweetsByUserId(
   });
 }
 
+export async function getTweetWhere(
+  options: TweetMatchOptions,
+  tweets: AsyncGenerator<Tweet>,
+): Promise<Tweet | null> {
+  for await (const tweet of tweets) {
+    const matches = Object.keys(options).every((k) => {
+      const key = k as keyof Tweet;
+      return tweet[key] == options[key];
+    });
+
+    if (matches) {
+      return tweet;
+    }
+  }
+
+  return null;
+}
+
 export async function getTweetsWhere(
   options: TweetMatchOptions,
   tweets: AsyncGenerator<Tweet>,
@@ -186,7 +204,7 @@ export async function getLatestTweet(
   // No point looping if max is 1, just use first entry.
   return max === 1
     ? (await timeline.next()).value
-    : await getTweetWhere('isRetweet', includeRetweets, timeline);
+    : await getTweetWhere({ isRetweet: includeRetweets }, timeline);
 }
 
 export async function getTweet(

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -159,8 +159,8 @@ export function getTweetsByUserId(
 }
 
 export async function getTweetWhere(
-  query: TweetQuery,
   tweets: AsyncIterable<Tweet>,
+  query: TweetQuery,
 ): Promise<Tweet | null> {
   const isCallback = typeof query === 'function';
 
@@ -176,8 +176,8 @@ export async function getTweetWhere(
 }
 
 export async function getTweetsWhere(
-  query: TweetQuery,
   tweets: AsyncIterable<Tweet>,
+  query: TweetQuery,
 ): Promise<Tweet[]> {
   const isCallback = typeof query === 'function';
   const filtered = [];


### PR DESCRIPTION
- implement `getTweetWhere`. Gets the first tweet matching the query, or null if no match.
- implement `getTweetsWhere`. An array of all tweets matching the query (or empty).
- support passing optional `max` variable to `getLatestTweet`.

Tests and documentation included for both new methods.