### PR TITLE
Nitter graphql port

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -131,6 +131,18 @@ export function addApiFeatures(o: object) {
     standardized_nudges_misinfo: true,
     longform_notetweets_rich_text_read_enabled: true,
     responsive_web_enhance_cards_enabled: false,
+    subscriptions_verification_info_enabled: true,
+    subscriptions_verification_info_reason_enabled: true,
+    subscriptions_verification_info_verified_since_enabled: true,
+    super_follow_badge_privacy_enabled: false,
+    super_follow_exclusive_tweet_notifications_enabled: false,
+    super_follow_tweet_api_enabled: false,
+    super_follow_user_api_enabled: false,
+    android_graphql_skip_api_media_color_palette: false,
+    creator_subscriptions_subscription_count_enabled: false,
+    blue_business_profile_image_shape_enabled: false,
+    unified_cards_ad_metadata_container_dynamic_card_content_query_enabled:
+      false,
   };
 }
 

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -111,7 +111,7 @@ export async function getProfile(
     }),
   );
   const res = await requestApi<UserRaw>(
-    `https://api.twitter.com/graphql/4S2ihIKfF3xhp-ENxvUAfQ/UserByScreenName?${params}`,
+    `https://api.twitter.com/graphql/4S2ihIKfF3xhp-ENxvUAfQ/UserResultByScreenNameQuery?${params}`,
     auth,
   );
   if (!res.success) {

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -1,4 +1,4 @@
-import stringify from 'json-stable-stringify'
+import stringify from 'json-stable-stringify';
 import { addApiFeatures, requestApi, RequestApiResult } from './api';
 import { TwitterAuth } from './auth';
 
@@ -50,7 +50,6 @@ export interface Profile {
   isPrivate?: boolean;
   isVerified?: boolean;
   isBlueVerified?: boolean;
-  hasNftAvatar?: boolean;
   joined?: Date;
   likesCount?: number;
   listedCount?: number;
@@ -70,7 +69,6 @@ export interface UserRaw {
       result: {
         rest_id?: string;
         isBlueVerified: boolean;
-        hasNftAvatar: boolean;
         legacy: LegacyUserRaw;
       };
     };
@@ -80,7 +78,10 @@ export interface UserRaw {
   }[];
 }
 
-export function parseProfile(user: LegacyUserRaw): Profile {
+export function parseProfile(
+  user: LegacyUserRaw,
+  isBlueVerified?: boolean,
+): Profile {
   const profile: Profile = {
     avatar: user.profile_image_url_https,
     banner: user.profile_banner_url,
@@ -100,6 +101,7 @@ export function parseProfile(user: LegacyUserRaw): Profile {
     url: `https://twitter.com/${user.screen_name}`,
     userId: user.id_str,
     username: user.screen_name,
+    isBlueVerified: isBlueVerified ?? false,
   };
 
   if (user.created_at != null) {
@@ -176,7 +178,7 @@ export async function getProfile(
 
   return {
     success: true,
-    value: parseProfile(user.legacy),
+    value: parseProfile(user.legacy, user.isBlueVerified),
   };
 }
 

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -111,7 +111,7 @@ export async function getProfile(
     }),
   );
   const res = await requestApi<UserRaw>(
-    `https://api.twitter.com/graphql/4S2ihIKfF3xhp-ENxvUAfQ/UserResultByScreenNameQuery?${params}`,
+    `https://api.twitter.com/graphql/u7wQyGi6oExe8_TRWGMq4Q/UserResultByScreenNameQuery?${params}`,
     auth,
   );
   if (!res.success) {

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -15,17 +15,23 @@ export interface LegacyUserRaw {
   favourites_count?: number;
   followers_count?: number;
   friends_count?: number;
+  media_count?: number;
+  statuses_count?: number;
   id_str?: string;
   listed_count?: number;
   name?: string;
   location: string;
+  geo_enabled?: boolean;
   pinned_tweet_ids_str?: string[];
+  profile_background_color?: string;
   profile_banner_url?: string;
   profile_image_url_https?: string;
   protected?: boolean;
   screen_name?: string;
-  statuses_count?: number;
   verified?: boolean;
+  has_custom_timelines?: boolean;
+  has_extended_profile?: boolean;
+  url?: string;
 }
 
 /**
@@ -39,8 +45,12 @@ export interface Profile {
   followersCount?: number;
   followingCount?: number;
   friendsCount?: number;
+  mediaCount?: number;
+  statusesCount?: number;
   isPrivate?: boolean;
   isVerified?: boolean;
+  isBlueVerified?: boolean;
+  hasNftAvatar?: boolean;
   joined?: Date;
   likesCount?: number;
   listedCount?: number;
@@ -59,6 +69,8 @@ export interface UserRaw {
     user_result: {
       result: {
         rest_id?: string;
+        isBlueVerified: boolean;
+        hasNftAvatar: boolean;
         legacy: LegacyUserRaw;
       };
     };
@@ -76,6 +88,7 @@ export function parseProfile(user: LegacyUserRaw): Profile {
     followersCount: user.followers_count,
     followingCount: user.favourites_count,
     friendsCount: user.friends_count,
+    mediaCount: user.media_count,
     isPrivate: user.protected,
     isVerified: user.verified,
     likesCount: user.favourites_count,
@@ -144,6 +157,7 @@ export async function getProfile(
 
   const { result: user } = value.data.user_result;
   const { legacy } = user;
+
   if (user.rest_id == null || user.rest_id.length === 0) {
     return {
       success: false,

--- a/src/search.test.ts
+++ b/src/search.test.ts
@@ -6,7 +6,7 @@ test('scraper can process search cursor', async () => {
   const scraper = await authSearchScraper();
 
   let cursor: string | undefined = undefined;
-  const maxTweets = 150;
+  const maxTweets = 30;
   let nTweets = 0;
   while (nTweets < maxTweets) {
     const res: QueryTweetsResponse = await scraper.fetchSearchTweets(
@@ -21,7 +21,7 @@ test('scraper can process search cursor', async () => {
     nTweets += res.tweets.length;
     cursor = res.next;
   }
-}, 1200000);
+}, 30000);
 
 test('scraper can search profiles', async () => {
   const scraper = await authSearchScraper();
@@ -29,18 +29,22 @@ test('scraper can search profiles', async () => {
   const seenProfiles = new Map<string, boolean>();
   const maxProfiles = 150;
   let nProfiles = 0;
-  for await (const profile of scraper.searchProfiles('Twitter', maxProfiles)) {
+
+  const profiles = scraper.searchProfiles('Twitter', maxProfiles);
+  for await (const profile of profiles) {
     nProfiles++;
 
-    expect(profile.userId).toBeTruthy();
-    if (profile.userId != null) {
-      expect(seenProfiles.has(profile.userId)).toBeFalsy();
-      seenProfiles.set(profile.userId, true);
+    const profileId = profile.userId;
+    expect(profileId).toBeTruthy();
+
+    if (profileId != null) {
+      expect(seenProfiles.has(profileId)).toBeFalsy();
+      seenProfiles.set(profileId, true);
     }
   }
 
   expect(nProfiles).toEqual(maxProfiles);
-}, 1200000);
+}, 30000);
 
 test('scraper can search tweets', async () => {
   const scraper = await authSearchScraper();
@@ -48,17 +52,22 @@ test('scraper can search tweets', async () => {
   const seenTweets = new Map<string, boolean>();
   const maxTweets = 150;
   let nTweets = 0;
-  for await (const tweet of scraper.searchTweets(
+
+  const profiles = scraper.searchTweets(
     'twitter',
     maxTweets,
     SearchMode.Latest,
-  )) {
+  );
+
+  for await (const tweet of profiles) {
     nTweets++;
 
-    expect(tweet.id).toBeTruthy();
-    if (tweet.id != null) {
-      expect(seenTweets.has(tweet.id)).toBeFalsy();
-      seenTweets.set(tweet.id, true);
+    const id = tweet.id;
+    expect(id).toBeTruthy();
+
+    if (id != null) {
+      expect(seenTweets.has(id)).toBeFalsy();
+      seenTweets.set(id, true);
     }
 
     expect(tweet.permanentUrl).toBeTruthy();
@@ -67,4 +76,4 @@ test('scraper can search tweets', async () => {
   }
 
   expect(nTweets).toEqual(maxTweets);
-}, 1200000);
+}, 30000);

--- a/src/search.ts
+++ b/src/search.ts
@@ -140,7 +140,7 @@ async function getSearchTimeline(
   params.set('variables', stringify(variables));
 
   const res = await requestApi<SearchTimeline>(
-    `https://twitter.com/i/api/graphql/nK1dw4oV3k4w5TdtcAdSww/SearchTimeline?${params.toString()}`,
+    `https://api.twitter.com/graphql/gkjsKepM6gl_HmFWoWKfgg/SearchTimeline?${params.toString()}`,
     auth,
   );
   if (!res.success) {

--- a/src/search.ts
+++ b/src/search.ts
@@ -107,6 +107,9 @@ async function getSearchTimeline(
     responsive_web_twitter_article_tweet_consumption_enabled: false,
     tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled:
       true,
+    interactive_text_enabled: false,
+    responsive_web_text_conversations_enabled: false,
+    vibe_api_enabled: false,
   });
 
   const fieldToggles: Record<string, any> = {
@@ -143,6 +146,7 @@ async function getSearchTimeline(
     `https://api.twitter.com/graphql/gkjsKepM6gl_HmFWoWKfgg/SearchTimeline?${params.toString()}`,
     auth,
   );
+
   if (!res.success) {
     throw res.err;
   }

--- a/src/timeline-search.ts
+++ b/src/timeline-search.ts
@@ -91,8 +91,13 @@ export function parseSearchTimelineUsers(
         const itemContent = entry.content?.itemContent;
         if (itemContent?.userDisplayType === 'User') {
           const userResultRaw = itemContent.user_results?.result;
+
           if (userResultRaw?.legacy) {
-            const profile = parseProfile(userResultRaw.legacy);
+            const profile = parseProfile(
+              userResultRaw.legacy,
+              userResultRaw.is_blue_verified,
+            );
+
             if (!profile.userId) {
               profile.userId = userResultRaw.rest_id;
             }

--- a/src/timeline-search.ts
+++ b/src/timeline-search.ts
@@ -1,6 +1,6 @@
 import { Profile, parseProfile } from './profile';
 import { QueryProfilesResponse, QueryTweetsResponse } from './timeline-v1';
-import { TimelineEntryRaw, parseLegacyTweet } from './timeline-v2';
+import { SearchEntryRaw, parseLegacyTweet } from './timeline-v2';
 import { Tweet } from './tweets';
 
 export interface SearchTimeline {
@@ -9,8 +9,8 @@ export interface SearchTimeline {
       search_timeline?: {
         timeline?: {
           instructions?: {
-            entries?: TimelineEntryRaw[];
-            entry?: TimelineEntryRaw;
+            entries?: SearchEntryRaw[];
+            entry?: SearchEntryRaw;
             type?: string;
           }[];
         };
@@ -37,14 +37,16 @@ export function parseSearchTimelineTweets(
         continue;
       }
 
-      for (const entry of instruction.entries ?? []) {
-        const itemContent = entry.content?.content;
+      const entries = instruction.entries ?? [];
+      for (const entry of entries) {
+        const itemContent = entry.content?.itemContent;
         if (itemContent?.tweetDisplayType === 'Tweet') {
-          const tweetResultRaw = itemContent.tweetResult?.result;
+          const tweetResultRaw = itemContent.tweet_results?.result;
           const tweetResult = parseLegacyTweet(
-            tweetResultRaw?.core?.user_result?.result?.legacy,
+            tweetResultRaw?.core?.user_results?.result?.legacy,
             tweetResultRaw?.legacy,
           );
+
           if (tweetResult.success) {
             if (!tweetResult.tweet.views && tweetResultRaw?.views?.count) {
               const views = parseInt(tweetResultRaw.views.count);
@@ -73,6 +75,7 @@ export function parseSearchTimelineUsers(
   const instructions =
     timeline.data?.search_by_raw_query?.search_timeline?.timeline
       ?.instructions ?? [];
+
   for (const instruction of instructions) {
     if (
       instruction.type === 'TimelineAddEntries' ||
@@ -83,14 +86,15 @@ export function parseSearchTimelineUsers(
         continue;
       }
 
-      for (const entry of instruction.entries ?? []) {
-        const itemContent = entry.content?.content;
+      const entries = instruction.entries ?? [];
+      for (const entry of entries) {
+        const itemContent = entry.content?.itemContent;
         if (itemContent?.userDisplayType === 'User') {
           const userResultRaw = itemContent.user_results?.result;
           if (userResultRaw?.legacy) {
             const profile = parseProfile(userResultRaw.legacy);
             if (!profile.userId) {
-              profile.userId = itemContent.user_results?.result?.rest_id;
+              profile.userId = userResultRaw.rest_id;
             }
 
             profiles.push(profile);

--- a/src/timeline-search.ts
+++ b/src/timeline-search.ts
@@ -38,11 +38,11 @@ export function parseSearchTimelineTweets(
       }
 
       for (const entry of instruction.entries ?? []) {
-        const itemContent = entry.content?.itemContent;
+        const itemContent = entry.content?.content;
         if (itemContent?.tweetDisplayType === 'Tweet') {
-          const tweetResultRaw = itemContent.tweet_results?.result;
+          const tweetResultRaw = itemContent.tweetResult?.result;
           const tweetResult = parseLegacyTweet(
-            tweetResultRaw?.core?.user_results?.result?.legacy,
+            tweetResultRaw?.core?.user_result?.result?.legacy,
             tweetResultRaw?.legacy,
           );
           if (tweetResult.success) {
@@ -84,7 +84,7 @@ export function parseSearchTimelineUsers(
       }
 
       for (const entry of instruction.entries ?? []) {
-        const itemContent = entry.content?.itemContent;
+        const itemContent = entry.content?.content;
         if (itemContent?.userDisplayType === 'User') {
           const userResultRaw = itemContent.user_results?.result;
           if (userResultRaw?.legacy) {

--- a/src/timeline-v1.ts
+++ b/src/timeline-v1.ts
@@ -49,6 +49,7 @@ export interface TimelineMediaExtendedRaw {
 }
 
 export interface TimelineResultRaw {
+  rest_id?: string;
   __typename?: string;
   core?: {
     user_result?: {

--- a/src/timeline-v1.ts
+++ b/src/timeline-v1.ts
@@ -51,7 +51,7 @@ export interface TimelineMediaExtendedRaw {
 export interface TimelineResultRaw {
   __typename?: string;
   core?: {
-    user_results?: {
+    user_result?: {
       result?: {
         is_blue_verified?: boolean;
         legacy?: LegacyUserRaw;

--- a/src/timeline-v1.ts
+++ b/src/timeline-v1.ts
@@ -88,7 +88,7 @@ export interface LegacyTweetRaw {
   extended_entities?: {
     media?: TimelineMediaExtendedRaw[];
   };
-  id_str?: string;
+  id_str: string;
   in_reply_to_status_id_str?: string;
   place?: PlaceRaw;
   reply_count?: number;

--- a/src/timeline-v1.ts
+++ b/src/timeline-v1.ts
@@ -48,6 +48,33 @@ export interface TimelineMediaExtendedRaw {
   video_info?: VideoInfo;
 }
 
+export interface SearchResultRaw {
+  rest_id?: string;
+  __typename?: string;
+  core?: {
+    user_results?: {
+      result?: {
+        is_blue_verified?: boolean;
+        legacy?: LegacyUserRaw;
+      };
+    };
+  };
+  views?: {
+    count?: string;
+  };
+  note_tweet?: {
+    note_tweet_results?: {
+      result?: {
+        text?: string;
+      };
+    };
+  };
+  quoted_status_result?: {
+    result?: SearchResultRaw;
+  };
+  legacy?: LegacyTweetRaw;
+}
+
 export interface TimelineResultRaw {
   rest_id?: string;
   __typename?: string;
@@ -89,7 +116,7 @@ export interface LegacyTweetRaw {
   extended_entities?: {
     media?: TimelineMediaExtendedRaw[];
   };
-  id_str: string;
+  id_str?: string;
   in_reply_to_status_id_str?: string;
   place?: PlaceRaw;
   reply_count?: number;

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -13,6 +13,7 @@ import { isFieldDefined } from './type-util';
 export interface TimelineUserResultRaw {
   rest_id?: string;
   legacy?: LegacyUserRaw;
+  is_blue_verified?: boolean;
 }
 
 export interface TimelineEntryItemContentRaw {
@@ -329,7 +330,8 @@ export function parseThreadedConversation(
   const tweets: Tweet[] = [];
   const instructions = conversation.data?.timeline_response?.instructions ?? [];
   for (const instruction of instructions) {
-    for (const entry of instruction.entries ?? []) {
+    const entries = instruction.entries ?? [];
+    for (const entry of entries) {
       const entryContent = entry.content?.content;
       if (entryContent) {
         parseAndPush(tweets, entryContent, entry.entryId, true);

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -236,7 +236,8 @@ export function parseTimelineTweetsV2(
       ?.instructions ?? [];
   for (const instruction of instructions) {
     for (const entry of instruction.entries ?? []) {
-      if (!entry.entryId.startsWith('tweet')) {
+      const idStr = entry.entryId;
+      if (!idStr.startsWith('tweet')) {
         continue;
       }
 
@@ -246,12 +247,13 @@ export function parseTimelineTweetsV2(
       }
 
       const result = entry.content?.content?.tweetResult?.result;
-      console.log(result?.core?.user_result?.result);
-
       if (result?.__typename === 'Tweet') {
+        if (result.legacy) {
+          result.legacy.id_str = idStr.replace('tweet-', '');
+        }
+
         const tweetResult = parseResult(result);
         if (tweetResult.success) {
-          //console.log(tweetResult);
           tweets.push(tweetResult.tweet);
         }
       }

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -40,12 +40,12 @@ export interface TimelineEntryRaw {
 
 export interface TimelineV2 {
   data?: {
-    user?: {
+    user_result?: {
       result?: {
-        timeline_v2?: {
+        timeline_response?: {
           timeline?: {
-            instructions?: {
-              entries?: TimelineEntryRaw[];
+            instructions: {
+              entries: TimelineEntryRaw[];
               entry?: TimelineEntryRaw;
               type?: string;
             }[];
@@ -233,7 +233,8 @@ export function parseTimelineTweetsV2(
   let cursor: string | undefined;
   const tweets: Tweet[] = [];
   const instructions =
-    timeline.data?.user?.result?.timeline_v2?.timeline?.instructions ?? [];
+    timeline.data?.user_result?.result?.timeline_response?.timeline
+      ?.instructions ?? [];
   for (const instruction of instructions) {
     for (const entry of instruction.entries ?? []) {
       if (entry.content?.cursorType === 'Bottom') {

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -4,6 +4,7 @@ import {
   LegacyTweetRaw,
   ParseTweetResult,
   QueryTweetsResponse,
+  SearchResultRaw,
   TimelineResultRaw,
 } from './timeline-v1';
 import { Tweet } from './tweets';
@@ -36,6 +37,34 @@ export interface TimelineEntryRaw {
       };
     }[];
     content?: TimelineEntryItemContentRaw;
+  };
+}
+
+export interface SearchEntryItemContentRaw {
+  tweetDisplayType?: string;
+  tweet_results?: {
+    result?: SearchResultRaw;
+  };
+  userDisplayType?: string;
+  user_results?: {
+    result?: TimelineUserResultRaw;
+  };
+}
+
+export interface SearchEntryRaw {
+  entryId: string;
+  sortIndex: string;
+  content?: {
+    cursorType?: string;
+    entryType?: string;
+    __typename?: string;
+    value?: string;
+    items?: {
+      item?: {
+        content?: SearchEntryItemContentRaw;
+      };
+    }[];
+    itemContent?: SearchEntryItemContentRaw;
   };
 }
 
@@ -86,10 +115,14 @@ export function parseLegacyTweet(
   }
 
   if (tweet.id_str == null) {
-    return {
-      success: false,
-      err: new Error('Tweet ID was not found in object.'),
-    };
+    if (!tweet.conversation_id_str) {
+      return {
+        success: false,
+        err: new Error('Tweet ID was not found in object.'),
+      };
+    }
+
+    tweet.id_str = tweet.conversation_id_str;
   }
 
   const hashtags = tweet.entities?.hashtags ?? [];

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -195,8 +195,11 @@ export function parseLegacyTweet(
 }
 
 function parseResult(result?: TimelineResultRaw): ParseTweetResult {
-  if (result?.legacy && result.note_tweet?.note_tweet_results?.result?.text) {
-    result.legacy.full_text = result.note_tweet.note_tweet_results.result.text;
+  const noteTweetResultText =
+    result?.note_tweet?.note_tweet_results?.result?.text;
+
+  if (result?.legacy && noteTweetResultText) {
+    result.legacy.full_text = noteTweetResultText;
   }
 
   const tweetResult = parseLegacyTweet(

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -235,18 +235,24 @@ export function parseTimelineTweetsV2(
     timeline.data?.user_result?.result?.timeline_response?.timeline
       ?.instructions ?? [];
   for (const instruction of instructions) {
-    for (const entry of instruction.entries ?? []) {
+    const entries = instruction.entries ?? [];
+    for (const entry of entries) {
+      const entryContent = entry.content;
+      if (!entryContent) continue;
+
+      if (entryContent.cursorType === 'Bottom') {
+        cursor = entryContent.value;
+        continue;
+      }
+
       const idStr = entry.entryId;
       if (!idStr.startsWith('tweet')) {
         continue;
       }
 
-      if (entry.content?.cursorType === 'Bottom') {
-        cursor = entry.content.value;
-        continue;
+      if (entryContent.content) {
+        parseAndPush(tweets, entryContent.content, idStr);
       }
-
-      parseAndPush(tweets, entry.content?.content, idStr);
     }
   }
 
@@ -255,7 +261,7 @@ export function parseTimelineTweetsV2(
 
 function parseAndPush(
   tweets: Tweet[],
-  content: any,
+  content: TimelineEntryItemContentRaw,
   entryId: string,
   isConversation = false,
 ) {
@@ -322,6 +328,5 @@ export function parseThreadedConversation(
     }
   }
 
-  //console.log(tweets);
   return tweets;
 }

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -6,6 +6,7 @@ import {
   parseTimelineTweetsV2,
   parseThreadedConversation,
   ThreadedConversation,
+  TimelineV2,
 } from './timeline-v2';
 import { getTweetTimeline } from './timeline-async';
 import stringify from 'json-stable-stringify';
@@ -116,7 +117,7 @@ export async function fetchTweets(
   params.set('variables', stringify(variables));
   params.set('features', stringify(features));
 
-  const res = await requestApi<any>(
+  const res = await requestApi<TimelineV2>(
     `https://api.twitter.com/graphql/8IS8MaO-2EN6GZZZb8jF0g/UserWithProfileTweetsAndRepliesQueryV2?${params.toString()}`,
     auth,
   );

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -91,12 +91,13 @@ export async function fetchTweets(
   }
 
   const variables: Record<string, any> = {
-    userId,
+    includeHasBirdwatchNotes: false,
+    rest_id: userId,
     count: maxTweets,
-    includePromotedContent: false,
-    withQuickPromoteEligibilityTweetFields: false,
-    withVoice: true,
-    withV2Timeline: true,
+    // includePromotedContent: false,
+    // withQuickPromoteEligibilityTweetFields: false,
+    // withVoice: true,
+    // withV2Timeline: true,
   };
 
   const features = addApiFeatures({
@@ -116,10 +117,11 @@ export async function fetchTweets(
   params.set('variables', stringify(variables));
   params.set('features', stringify(features));
 
-  const res = await requestApi<TimelineV2>(
-    `https://twitter.com/i/api/graphql/UGi7tjRPr-d_U3bCPIko5Q/UserTweets?${params.toString()}`,
+  const res = await requestApi<any>(
+    `https://api.twitter.com/graphql/3JNH4e9dq1BifLxAa3UMWg/UserWithProfileTweetsQueryV2?${params.toString()}`,
     auth,
   );
+
   if (!res.success) {
     throw res.err;
   }
@@ -134,6 +136,7 @@ export function getTweets(
 ): AsyncGenerator<Tweet, void> {
   return getTweetTimeline(user, maxTweets, async (q, mt, c) => {
     const userIdRes = await getUserIdByScreenName(q, auth);
+
     if (!userIdRes.success) {
       throw userIdRes.err;
     }
@@ -188,6 +191,7 @@ export async function getTweet(
     withBirdwatchNotes: true,
     withVoice: true,
     withV2Timeline: true,
+    includeHasBirdwatchNotes: false,
   };
 
   const features = addApiFeatures({
@@ -201,7 +205,7 @@ export async function getTweet(
   params.set('variables', stringify(variables));
 
   const res = await requestApi<ThreadedConversation>(
-    `https://twitter.com/i/api/graphql/VWFGPVAGkZMGRKGe3GFFnA/TweetDetail?${params.toString()}`,
+    `https://api.twitter.com/graphql/83h5UyHZ9wEKBVzALX8R_g/ConversationTimelineV2?${params.toString()}`,
     auth,
   );
   if (!res.success) {

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -83,6 +83,15 @@ export type TweetQuery =
   | Partial<Tweet>
   | ((tweet: Tweet) => boolean | Promise<boolean>);
 
+export const features = addApiFeatures({
+  interactive_text_enabled: true,
+  longform_notetweets_inline_media_enabled: false,
+  responsive_web_text_conversations_enabled: false,
+  tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled:
+    false,
+  vibe_api_enabled: false,
+});
+
 export async function fetchTweets(
   userId: string,
   maxTweets: number,
@@ -98,15 +107,6 @@ export async function fetchTweets(
     rest_id: userId,
     count: maxTweets,
   };
-
-  const features = addApiFeatures({
-    interactive_text_enabled: true,
-    longform_notetweets_inline_media_enabled: false,
-    responsive_web_text_conversations_enabled: false,
-    tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled:
-      false,
-    vibe_api_enabled: false,
-  });
 
   if (cursor != null && cursor != '') {
     variables['cursor'] = cursor;
@@ -219,21 +219,8 @@ export async function getTweet(
 ): Promise<Tweet | null> {
   const variables: Record<string, any> = {
     focalTweetId: id,
-    with_rux_injections: false,
-    includePromotedContent: true,
-    withCommunity: true,
-    withQuickPromoteEligibilityTweetFields: true,
-    withBirdwatchNotes: true,
-    withVoice: true,
-    withV2Timeline: true,
     includeHasBirdwatchNotes: false,
   };
-
-  const features = addApiFeatures({
-    longform_notetweets_inline_media_enabled: true,
-    tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled:
-      false,
-  });
 
   const params = new URLSearchParams();
   params.set('features', stringify(features));

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -106,7 +106,7 @@ export async function fetchTweets(
     responsive_web_text_conversations_enabled: false,
     tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled:
       false,
-    vibe_api_enabled: true,
+    vibe_api_enabled: false,
   });
 
   if (cursor != null && cursor != '') {

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -3,7 +3,6 @@ import { TwitterAuth } from './auth';
 import { getUserIdByScreenName } from './profile';
 import { QueryTweetsResponse } from './timeline-v1';
 import {
-  TimelineV2,
   parseTimelineTweetsV2,
   parseThreadedConversation,
   ThreadedConversation,
@@ -98,10 +97,6 @@ export async function fetchTweets(
     includeHasBirdwatchNotes: false,
     rest_id: userId,
     count: maxTweets,
-    // includePromotedContent: false,
-    // withQuickPromoteEligibilityTweetFields: false,
-    // withVoice: true,
-    // withV2Timeline: true,
   };
 
   const features = addApiFeatures({

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -122,7 +122,7 @@ export async function fetchTweets(
   params.set('features', stringify(features));
 
   const res = await requestApi<any>(
-    `https://api.twitter.com/graphql/3JNH4e9dq1BifLxAa3UMWg/UserWithProfileTweetsQueryV2?${params.toString()}`,
+    `https://api.twitter.com/graphql/8IS8MaO-2EN6GZZZb8jF0g/UserWithProfileTweetsAndRepliesQueryV2?${params.toString()}`,
     auth,
   );
 
@@ -248,16 +248,11 @@ export async function getTweet(
     `https://api.twitter.com/graphql/83h5UyHZ9wEKBVzALX8R_g/ConversationTimelineV2?${params.toString()}`,
     auth,
   );
+
   if (!res.success) {
     throw res.err;
   }
 
   const tweets = parseThreadedConversation(res.value);
-  for (const tweet of tweets) {
-    if (tweet.id === id) {
-      return tweet;
-    }
-  }
-
-  return null;
+  return tweets.find((t) => t.id === id) ?? null;
 }


### PR DESCRIPTION
Ports the new GraphQL endpoints and parsing edits as seen [here](https://github.com/zedeus/nitter/commit/0bc3c153d9b38a3c02f321fb64a375fef6b97e8e).

**Notes**: 
- Implemented `isBlueVerified` and `mediaCount` on the `Profile` interface.
- Tweet `views` property no longer exists and so that test will fail - a solution is required to restore this.
- All other tests pass, but I cannot be sure every single method returns data as intended.

Fixes #34