### PR TITLE
feat: add photo alt text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,5 +106,8 @@ dist
 # VSCode
 .vscode/
 
+# JetBrains
+.idea/
+
 # Documentation
 docs/

--- a/src/timeline-tweet-util.ts
+++ b/src/timeline-tweet-util.ts
@@ -22,6 +22,7 @@ export function parseMediaGroups(media: TimelineMediaExtendedRaw[]): {
       photos.push({
         id: m.id_str,
         url: m.media_url_https,
+        alt_text: m.ext_alt_text,
       });
     } else if (m.type === 'video') {
       videos.push(parseVideo(m));

--- a/src/timeline-v1.ts
+++ b/src/timeline-v1.ts
@@ -46,6 +46,7 @@ export interface TimelineMediaExtendedRaw {
   type?: string;
   url?: string;
   video_info?: VideoInfo;
+  ext_alt_text: string | undefined;
 }
 
 export interface SearchResultRaw {

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -20,6 +20,7 @@ export interface Mention {
 export interface Photo {
   id: string;
   url: string;
+  alt_text: string | undefined;
 }
 
 export interface Video {


### PR DESCRIPTION
The PR allows `parseMediaGroups` to parse the Tweet photos `ext_alt_text` prop and inject it in parsed `Photo`

Tips:
- `ext_alt_text` can be `string | undefined`
- media are already filtered on `id_str` and `media_url_https` being defined. Now, they are also generated with `ext_alt_text` that can be `undefined`.