### PR TITLE
feat(profile): provide original avatar size url

### DIFF
--- a/src/profile.ts
+++ b/src/profile.ts
@@ -78,7 +78,7 @@ export interface UserRaw {
   }[];
 }
 
-export function getAvatarOriginalSizeUrl(avatarUrl: string | undefined) {
+function getAvatarOriginalSizeUrl(avatarUrl: string | undefined) {
   return avatarUrl ? avatarUrl.replace('_normal', '') : undefined;
 }
 

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -78,12 +78,16 @@ export interface UserRaw {
   }[];
 }
 
+export function getAvatarOriginalSizeUrl(avatarUrl: string | undefined) {
+  return avatarUrl ? avatarUrl.replace('_normal', '') : undefined;
+}
+
 export function parseProfile(
   user: LegacyUserRaw,
   isBlueVerified?: boolean,
 ): Profile {
   const profile: Profile = {
-    avatar: user.profile_image_url_https,
+    avatar: getAvatarOriginalSizeUrl(user.profile_image_url_https),
     banner: user.profile_banner_url,
     biography: user.description,
     followersCount: user.followers_count,


### PR DESCRIPTION
This MR allows profile parsing to return a full size avatar url instead of the `normal` size returned by default by the api.

API Reference: https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/user-profile-images-and-banners