### PR TITLE
feat(timeline): add low-level support for top cursors

### DIFF
--- a/src/timeline-search.ts
+++ b/src/timeline-search.ts
@@ -22,7 +22,8 @@ export interface SearchTimeline {
 export function parseSearchTimelineTweets(
   timeline: SearchTimeline,
 ): QueryTweetsResponse {
-  let cursor: string | undefined;
+  let bottomCursor: string | undefined;
+  let topCursor: string | undefined;
   const tweets: Tweet[] = [];
   const instructions =
     timeline.data?.search_by_raw_query?.search_timeline?.timeline
@@ -33,7 +34,10 @@ export function parseSearchTimelineTweets(
       instruction.type === 'TimelineReplaceEntry'
     ) {
       if (instruction.entry?.content?.cursorType === 'Bottom') {
-        cursor = instruction.entry.content.value;
+        bottomCursor = instruction.entry.content.value;
+        continue;
+      } else if (instruction.entry?.content?.cursorType === 'Top') {
+        topCursor = instruction.entry.content.value;
         continue;
       }
 
@@ -58,19 +62,22 @@ export function parseSearchTimelineTweets(
             tweets.push(tweetResult.tweet);
           }
         } else if (entry.content?.cursorType === 'Bottom') {
-          cursor = entry.content.value;
+          bottomCursor = entry.content.value;
+        } else if (entry.content?.cursorType === 'Top') {
+          topCursor = entry.content.value;
         }
       }
     }
   }
 
-  return { tweets, next: cursor };
+  return { tweets, next: bottomCursor, previous: topCursor };
 }
 
 export function parseSearchTimelineUsers(
   timeline: SearchTimeline,
 ): QueryProfilesResponse {
-  let cursor: string | undefined;
+  let bottomCursor: string | undefined;
+  let topCursor: string | undefined;
   const profiles: Profile[] = [];
   const instructions =
     timeline.data?.search_by_raw_query?.search_timeline?.timeline
@@ -82,7 +89,10 @@ export function parseSearchTimelineUsers(
       instruction.type === 'TimelineReplaceEntry'
     ) {
       if (instruction.entry?.content?.cursorType === 'Bottom') {
-        cursor = instruction.entry.content.value;
+        bottomCursor = instruction.entry.content.value;
+        continue;
+      } else if (instruction.entry?.content?.cursorType === 'Top') {
+        topCursor = instruction.entry.content.value;
         continue;
       }
 
@@ -105,11 +115,13 @@ export function parseSearchTimelineUsers(
             profiles.push(profile);
           }
         } else if (entry.content?.cursorType === 'Bottom') {
-          cursor = entry.content.value;
+          bottomCursor = entry.content.value;
+        } else if (entry.content?.cursorType === 'Top') {
+          topCursor = entry.content.value;
         }
       }
     }
   }
 
-  return { profiles, next: cursor };
+  return { profiles, next: bottomCursor, previous: topCursor };
 }

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -268,7 +268,8 @@ function parseResult(result?: TimelineResultRaw): ParseTweetResult {
 export function parseTimelineTweetsV2(
   timeline: TimelineV2,
 ): QueryTweetsResponse {
-  let cursor: string | undefined;
+  let bottomCursor: string | undefined;
+  let topCursor: string | undefined;
   const tweets: Tweet[] = [];
   const instructions =
     timeline.data?.user?.result?.timeline_response?.timeline?.instructions ??
@@ -281,7 +282,10 @@ export function parseTimelineTweetsV2(
       if (!entryContent) continue;
 
       if (entryContent.cursorType === 'Bottom') {
-        cursor = entryContent.value;
+        bottomCursor = entryContent.value;
+        continue;
+      } else if (entryContent.cursorType === 'Top') {
+        topCursor = entryContent.value;
         continue;
       }
 
@@ -296,7 +300,7 @@ export function parseTimelineTweetsV2(
     }
   }
 
-  return { tweets, next: cursor };
+  return { tweets, next: bottomCursor, previous: topCursor };
 }
 
 export function parseTimelineEntryItemContentRaw(


### PR DESCRIPTION
Previously only bottom cursors were parsed and returned. This prevents the library from being used for real-time scraping, as it can only iterate historical items in queries  with no way to fetch new results since the initial query. This patch adds a `previous` cursor to timeline responses.

Related: #54 