### PR TITLE
fix: use friends_count for follower count

### DIFF
--- a/src/profile.ts
+++ b/src/profile.ts
@@ -90,7 +90,7 @@ export function parseProfile(
     banner: user.profile_banner_url,
     biography: user.description,
     followersCount: user.followers_count,
-    followingCount: user.favourites_count,
+    followingCount: user.friends_count,
     friendsCount: user.friends_count,
     mediaCount: user.media_count,
     isPrivate: user.protected ?? false,

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -11,7 +11,6 @@ import {
   parseThreadedConversation,
 } from './timeline-v2';
 import { getTweetTimeline } from './timeline-async';
-import stringify from 'json-stable-stringify';
 import { apiRequestFactory } from './api-data';
 
 export interface Mention {


### PR DESCRIPTION
See #66. Choosing to change how the value is filled instead of removing it for backwards-compatibility.