### PR TITLE
add list-conversation tweets support for fetchListTweets

### DIFF
--- a/src/timeline-list.ts
+++ b/src/timeline-list.ts
@@ -1,5 +1,5 @@
 import { QueryTweetsResponse } from './timeline-v1';
-import { SearchEntryRaw, parseAndPush } from './timeline-v2';
+import {parseAndPush, TimelineEntryRaw} from './timeline-v2';
 import { Tweet } from './tweets';
 
 export interface ListTimeline {
@@ -8,8 +8,8 @@ export interface ListTimeline {
       tweets_timeline?: {
         timeline?: {
           instructions?: {
-            entries?: SearchEntryRaw[];
-            entry?: SearchEntryRaw;
+            entries?: TimelineEntryRaw[];
+            entry?: TimelineEntryRaw;
             type?: string;
           }[];
         };
@@ -43,12 +43,18 @@ export function parseListTimelineTweets(
       }
 
       const idStr = entry.entryId;
-      if (!idStr.startsWith('tweet')) {
+      if (!idStr.startsWith('tweet') && !idStr.startsWith('list-conversation')) {
         continue;
       }
 
       if (entryContent.itemContent) {
         parseAndPush(tweets, entryContent.itemContent, idStr);
+      } else if (entryContent.items) {
+        for (const contentItem of entryContent.items) {
+          if (contentItem.item && contentItem.item.itemContent && contentItem.entryId) {
+            parseAndPush(tweets, contentItem.item.itemContent, contentItem.entryId.split('tweet-')[1]);
+          }
+        }
       }
     }
   }

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -37,8 +37,10 @@ export interface TimelineEntryRaw {
     cursorType?: string;
     value?: string;
     items?: {
+      entryId?: string;
       item?: {
         content?: TimelineEntryItemContentRaw;
+        itemContent?: SearchEntryItemContentRaw;
       };
     }[];
     itemContent?: TimelineEntryItemContentRaw;


### PR DESCRIPTION
This pull request fixes a problem of skipping replies to tweets in list timeline. Here the example of structure of reply in list:

<img width="1440" alt="image" src="https://github.com/the-convocation/twitter-scraper/assets/4842007/e9ae61a3-9663-4d76-8c80-234ca1dd402a">

.
This pull request was tested by checking fetchListTweets results in  my app and works well for me.