### PR TITLE
fix: getFollowers not returning all followers

### DIFF
--- a/src/profile.ts
+++ b/src/profile.ts
@@ -170,6 +170,12 @@ export async function getProfile(
     };
   }
 
+  if (!value.data || !value.data.user || !value.data.user.result) {
+    return {
+      success: false,
+      err: new Error('User not found.'),
+    };
+  }
   const { result: user } = value.data.user;
   const { legacy } = user;
 

--- a/src/timeline-async.ts
+++ b/src/timeline-async.ts
@@ -30,6 +30,7 @@ export async function* getUserTimeline(
 ): AsyncGenerator<Profile, void> {
   let nProfiles = 0;
   let cursor: string | undefined = undefined;
+  let consecutiveEmptyBatches = 0;
   while (nProfiles < maxProfiles) {
     const batch: FetchProfilesResponse = await fetchFunc(
       query,
@@ -38,21 +39,20 @@ export async function* getUserTimeline(
     );
 
     const { profiles, next } = batch;
+    cursor = next;
 
     if (profiles.length === 0) {
-      break;
-    }
+      consecutiveEmptyBatches++;
+      if (consecutiveEmptyBatches > 5) break;
+    } else consecutiveEmptyBatches = 0;
 
     for (const profile of profiles) {
-      if (nProfiles < maxProfiles) {
-        cursor = next;
-        yield profile;
-      } else {
-        break;
-      }
-
+      if (nProfiles < maxProfiles) yield profile;
+      else break;
       nProfiles++;
     }
+
+    if (!next) break;
   }
 }
 


### PR DESCRIPTION
- Fix #69 
- Catch an error when trying to fetch profile of non-existent user

Problem for #69 was that it for whatever reason returned one empty page at some point even though the pages after that still contained results. Fixed by breaking from the loop only when there have been 5 consecutive empty pages (or the cursor to next page is undefined).