### PR TITLE
Handle profile conversations in TimelineTimelineModule entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@the-convocation/twitter-scraper",
   "description": "A port of n0madic/twitter-scraper to Node.js.",
   "keywords": ["x", "twitter", "scraper"],
-  "version": "0.9.2",
+  "version": "0.9.3",
   "main": "dist/_module.js",
   "repository": "https://github.com/the-convocation/twitter-scraper.git",
   "author": "karashiiro <49822414+karashiiro@users.noreply.github.com>",

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -167,9 +167,9 @@ export class Scraper {
    * @returns A page of results, containing a cursor that can be used in further requests.
    */
   public fetchListTweets(
-      listId: string,
-      maxTweets: number,
-      cursor?: string,
+    listId: string,
+    maxTweets: number,
+    cursor?: string,
   ): Promise<QueryTweetsResponse> {
     return fetchListTweets(listId, maxTweets, cursor, this.auth);
   }

--- a/src/timeline-list.ts
+++ b/src/timeline-list.ts
@@ -1,5 +1,5 @@
 import { QueryTweetsResponse } from './timeline-v1';
-import {parseAndPush, TimelineEntryRaw} from './timeline-v2';
+import { parseAndPush, TimelineEntryRaw } from './timeline-v2';
 import { Tweet } from './tweets';
 
 export interface ListTimeline {
@@ -25,8 +25,7 @@ export function parseListTimelineTweets(
   let topCursor: string | undefined;
   const tweets: Tweet[] = [];
   const instructions =
-    timeline.data?.list?.tweets_timeline?.timeline
-      ?.instructions ?? [];
+    timeline.data?.list?.tweets_timeline?.timeline?.instructions ?? [];
   for (const instruction of instructions) {
     const entries = instruction.entries ?? [];
 
@@ -43,7 +42,10 @@ export function parseListTimelineTweets(
       }
 
       const idStr = entry.entryId;
-      if (!idStr.startsWith('tweet') && !idStr.startsWith('list-conversation')) {
+      if (
+        !idStr.startsWith('tweet') &&
+        !idStr.startsWith('list-conversation')
+      ) {
         continue;
       }
 
@@ -51,8 +53,16 @@ export function parseListTimelineTweets(
         parseAndPush(tweets, entryContent.itemContent, idStr);
       } else if (entryContent.items) {
         for (const contentItem of entryContent.items) {
-          if (contentItem.item && contentItem.item.itemContent && contentItem.entryId) {
-            parseAndPush(tweets, contentItem.item.itemContent, contentItem.entryId.split('tweet-')[1]);
+          if (
+            contentItem.item &&
+            contentItem.item.itemContent &&
+            contentItem.entryId
+          ) {
+            parseAndPush(
+              tweets,
+              contentItem.item.itemContent,
+              contentItem.entryId.split('tweet-')[1],
+            );
           }
         }
       }

--- a/src/tweets.test.ts
+++ b/src/tweets.test.ts
@@ -1,7 +1,7 @@
 import { getScraper } from './test-utils';
 import { Mention, Tweet } from './tweets';
-import {QueryTweetsResponse} from "./timeline-v1";
-import {SearchMode} from "./search";
+import { QueryTweetsResponse } from './timeline-v1';
+import { SearchMode } from './search';
 
 test('scraper can get tweet', async () => {
   const expected: Tweet = {
@@ -60,9 +60,9 @@ test('scraper can get tweets from list', async () => {
   let nTweets = 0;
   while (nTweets < maxTweets) {
     const res: QueryTweetsResponse = await scraper.fetchListTweets(
-        '1736495155002106192',
-        maxTweets,
-        cursor,
+      '1736495155002106192',
+      maxTweets,
+      cursor,
     );
 
     expect(res.next).toBeTruthy();

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -12,7 +12,7 @@ import {
 } from './timeline-v2';
 import { getTweetTimeline } from './timeline-async';
 import { apiRequestFactory } from './api-data';
-import {ListTimeline, parseListTimelineTweets} from "./timeline-list";
+import { ListTimeline, parseListTimelineTweets } from './timeline-list';
 
 export interface Mention {
   id: string;
@@ -129,10 +129,10 @@ export async function fetchTweets(
 }
 
 export async function fetchListTweets(
-    listId: string,
-    maxTweets: number,
-    cursor: string | undefined,
-    auth: TwitterAuth,
+  listId: string,
+  maxTweets: number,
+  cursor: string | undefined,
+  auth: TwitterAuth,
 ): Promise<QueryTweetsResponse> {
   if (maxTweets > 200) {
     maxTweets = 200;
@@ -147,8 +147,8 @@ export async function fetchListTweets(
   }
 
   const res = await requestApi<ListTimeline>(
-      listTweetsRequest.toRequestUrl(),
-      auth,
+    listTweetsRequest.toRequestUrl(),
+    auth,
   );
 
   if (!res.success) {


### PR DESCRIPTION
Fixes #73.

Most timeline entries are `TimelineTimelineTweet` entries and just contain a tweet, but some entries are `TimelineTimelineModule` entries, such as profile conversations, which contain a set of tweets. This adds handling for the latter case.