### PR TITLE
refactor user auth & implement 2FA

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@the-convocation/twitter-scraper",
   "description": "A port of n0madic/twitter-scraper to Node.js.",
-  "keywords": ["x", "twitter", "scraper", "crawler"],
+  "keywords": [
+    "x",
+    "twitter",
+    "scraper",
+    "crawler"
+  ],
   "version": "0.10.1",
   "main": "dist/_module.js",
   "repository": "https://github.com/the-convocation/twitter-scraper.git",
@@ -21,6 +26,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@sinclair/typebox": "^0.32.20",
     "cross-fetch": "^4.0.0-alpha.5",
     "headers-polyfill": "^3.1.2",
     "json-stable-stringify": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cross-fetch": "^4.0.0-alpha.5",
     "headers-polyfill": "^3.1.2",
     "json-stable-stringify": "^1.0.2",
+    "otpauth": "^9.2.2",
     "set-cookie-parser": "^2.6.0",
     "tough-cookie": "^4.1.2",
     "tslib": "^2.5.2"

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -27,9 +27,15 @@ export interface TwitterAuth {
    * Logs into a Twitter account.
    * @param username The username to log in with.
    * @param password The password to log in with.
-   * @param email The password to log in with, if you have email confirmation enabled.
+   * @param email The email to log in with, if you have email confirmation enabled.
+   * @param twoFactorSecret The secret to generate two factor authentication tokens with, if you have two factor authentication enabled.
    */
-  login(username: string, password: string, email?: string): Promise<void>;
+  login(
+    username: string,
+    password: string,
+    email?: string,
+    twoFactorSecret?: string,
+  ): Promise<void>;
 
   /**
    * Logs out of the current session.

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -368,16 +368,18 @@ export class Scraper {
    * searches.
    * @param username The username of the Twitter account to login with.
    * @param password The password of the Twitter account to login with.
-   * @param email The password to log in with, if you have email confirmation enabled.
+   * @param email The email to log in with, if you have email confirmation enabled.
+   * @param twoFactorSecret The secret to generate two factor authentication tokens with, if you have two factor authentication enabled.
    */
   public async login(
     username: string,
     password: string,
     email?: string,
+    twoFactorSecret?: string,
   ): Promise<void> {
     // Swap in a real authorizer for all requests
     const userAuth = new TwitterUserAuth(this.token, this.getAuthOptions());
-    await userAuth.login(username, password, email);
+    await userAuth.login(username, password, email, twoFactorSecret);
     this.auth = userAuth;
     this.authTrends = userAuth;
   }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -16,6 +16,7 @@ export async function getScraper(
   const username = process.env['TWITTER_USERNAME'];
   const password = process.env['TWITTER_PASSWORD'];
   const email = process.env['TWITTER_EMAIL'];
+  const twoFactorSecret = process.env['TWITTER_2FA_SECRET'];
   const cookies = process.env['TWITTER_COOKIES'];
   const proxyUrl = process.env['PROXY_URL'];
   let agent: any;
@@ -51,7 +52,7 @@ export async function getScraper(
   });
 
   if (options.authMethod === 'password') {
-    await scraper.login(username!, password!, email);
+    await scraper.login(username!, password!, email, twoFactorSecret);
   } else if (options.authMethod === 'cookies') {
     await scraper.setCookies(JSON.parse(cookies!));
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,6 +795,11 @@
   resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
+"@sinclair/typebox@^0.32.20":
+  version "0.32.20"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.32.20.tgz#32bdeb6b185188622f965ebbc88e1a6d5127d88a"
+  integrity sha512-ziK497ILSIYMxD/thl496idIb03IZPlha04itLQu1xAFQbumWZ+Dj4PMMCkDRpAYhvVSdmRlTjGu2B2MA5RplQ==
+
 "@sinonjs/commons@^3.0.0":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3102,6 +3102,11 @@ jsonparse@^1.2.0:
   resolved "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
+jssha@~3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jssha/-/jssha-3.3.1.tgz#c5b7fc7fb9aa745461923b87df0e247dd59c7ea8"
+  integrity sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==
+
 keyv@^4.5.3:
   version "4.5.3"
   resolved "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz"
@@ -3554,6 +3559,13 @@ os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
+
+otpauth@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/otpauth/-/otpauth-9.2.2.tgz#64bda9ea501a5d86e69a964a45062f1f17f740f4"
+  integrity sha512-2VcnYRUmq1dNckIfySNYP32ITWp1bvTeAEW0BSCR6G3GBf3a5zb9E+ubY62t3Dma9RjoHlvd7QpmzHfJZRkiNg==
+  dependencies:
+    jssha "~3.3.1"
 
 p-limit@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
this puts it more in line with what twscrape does and should be more resilient to upstream changes

2FA gets tested if a `TWITTER_2FA_TOKEN` is specified, but isn't otherwise.