### PR TITLE
fix: parse tweetwithvisibilityresults type

### DIFF
--- a/src/timeline-v1.ts
+++ b/src/timeline-v1.ts
@@ -101,6 +101,7 @@ export interface TimelineResultRaw {
     result?: TimelineResultRaw;
   };
   legacy?: LegacyTweetRaw;
+  tweet?: TimelineResultRaw;
 }
 
 export interface LegacyTweetRaw {

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -326,9 +326,15 @@ export function parseTimelineEntryItemContentRaw(
   entryId: string,
   isConversation = false,
 ) {
-  const result = content.tweet_results?.result ?? content.tweetResult?.result;
-  if (result?.__typename === 'Tweet') {
-    if (result.legacy) {
+  let result = content.tweet_results?.result ?? content.tweetResult?.result;
+  if (
+    result?.__typename === 'Tweet' ||
+    (result?.__typename === 'TweetWithVisibilityResults' && result?.tweet)
+  ) {
+    if (result?.__typename === 'TweetWithVisibilityResults')
+      result = result.tweet;
+
+    if (result?.legacy) {
       result.legacy.id_str =
         result.rest_id ??
         entryId.replace('conversation-', '').replace('tweet-', '');


### PR DESCRIPTION
Tweets that have limited replies (such as [1779717986082849241](https://twitter.com/sachi_sachiko/status/1779717986082849241))are not being parsed correctly, the object returned is of __typename 'TweetWithVisibilityResults' and contains a tweet property with the actual tweet. 

Once set the result to the tweet of the wrapped object, parsing seems to be performing good