### PR TITLE
feat: include raw tweet as part of results

### DIFF
--- a/src/timeline-v1.ts
+++ b/src/timeline-v1.ts
@@ -229,19 +229,21 @@ export type ParseTweetResult =
 
 function parseTimelineTweet(
   timeline: TimelineV1,
-  id: string,
+  tweetId: string,
 ): ParseTweetResult {
   const tweets = timeline.globalObjects?.tweets ?? {};
-  const tweet = tweets[id];
+  const tweet: Readonly<LegacyTweetRaw> | undefined = tweets[tweetId];
   if (tweet?.user_id_str == null) {
     return {
       success: false,
-      err: new Error(`Tweet "${id}" was not found in the timeline object.`),
+      err: new Error(
+        `Tweet "${tweetId}" was not found in the timeline object.`,
+      ),
     };
   }
 
   const users = timeline.globalObjects?.users ?? {};
-  const user = users[tweet.user_id_str];
+  const user: Readonly<LegacyUserRaw> | undefined = users[tweet.user_id_str];
   if (user?.screen_name == null) {
     return {
       success: false,
@@ -259,8 +261,9 @@ function parseTimelineTweet(
   const { photos, videos, sensitiveContent } = parseMediaGroups(media);
 
   const tw: Tweet = {
+    __raw_UNSTABLE: tweet,
     conversationId: tweet.conversation_id_str,
-    id,
+    id: tweetId,
     hashtags: hashtags
       .filter(isFieldDefined('text'))
       .map((hashtag) => hashtag.text),
@@ -271,7 +274,7 @@ function parseTimelineTweet(
       name: mention.name,
     })),
     name: user.name,
-    permanentUrl: `https://twitter.com/${user.screen_name}/status/${id}`,
+    permanentUrl: `https://twitter.com/${user.screen_name}/status/${tweetId}`,
     photos,
     replies: tweet.reply_count,
     retweets: tweet.retweet_count,

--- a/src/tweets.test.ts
+++ b/src/tweets.test.ts
@@ -1,7 +1,6 @@
 import { getScraper } from './test-utils';
 import { Mention, Tweet } from './tweets';
 import { QueryTweetsResponse } from './timeline-v1';
-import { SearchMode } from './search';
 
 test('scraper can get tweet', async () => {
   const expected: Tweet = {

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -1,7 +1,7 @@
 import { addApiFeatures, requestApi } from './api';
 import { TwitterAuth } from './auth';
 import { getUserIdByScreenName } from './profile';
-import { QueryTweetsResponse } from './timeline-v1';
+import { LegacyTweetRaw, QueryTweetsResponse } from './timeline-v1';
 import {
   parseTimelineTweetsV2,
   TimelineV2,
@@ -49,6 +49,7 @@ export interface PlaceRaw {
  * A parsed Tweet object.
  */
 export interface Tweet {
+  __raw_UNSTABLE?: LegacyTweetRaw;
   bookmarkCount?: number;
   conversationId?: string;
   hashtags: string[];


### PR DESCRIPTION
Adds a new `__raw_UNSTABLE` property on Tweet objects with the original tweet. This should help with both extracting more data than the scraper typically provides, reprocessing the original data in a different way, and simple debugging. No compatibility guarantees are currently made for this field.