### PR TITLE
Support custom auth subtask registration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,13 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   setupFiles: ['dotenv/config', './test-setup.js'],
+  collectCoverage: true,
+  collectCoverageFrom: [
+    'src/**/*.{js,ts}',
+    '!src/index.ts',
+    '!src/**/*.d.ts',
+    '!src/**/*.test.{js,ts}',
+    '!src/**/*.spec.{js,ts}',
+  ],
+  coverageDirectory: 'coverage',
 };

--- a/src/_module.ts
+++ b/src/_module.ts
@@ -1,5 +1,17 @@
 export type { FetchTransformOptions } from './api';
 export type { FetchParameters } from './api-types';
+export type {
+  TwitterUserAuthCredentials,
+  TwitterUserAuthFlowInitRequest,
+  TwitterUserAuthFlowSubtaskRequest,
+  TwitterUserAuthFlowRequest,
+  TwitterUserAuthFlowResponse,
+  FlowSubtaskHandler,
+  FlowSubtaskHandlerApi,
+  FlowTokenResult,
+  FlowTokenResultError,
+  FlowTokenResultSuccess,
+} from './auth-user';
 export { ApiError } from './errors';
 export type { Profile } from './profile';
 export {

--- a/src/_module.ts
+++ b/src/_module.ts
@@ -12,7 +12,14 @@ export type {
   FlowTokenResultError,
   FlowTokenResultSuccess,
 } from './auth-user';
-export { ApiError } from './errors';
+export {
+  ApiError,
+  AuthenticationError,
+  type TwitterApiErrorRaw,
+  type TwitterApiErrorExtensions,
+  type TwitterApiErrorPosition,
+  type TwitterApiErrorTraceInfo,
+} from './errors';
 export type { Profile } from './profile';
 export {
   type RateLimitEvent,

--- a/src/auth-user.test.ts
+++ b/src/auth-user.test.ts
@@ -1,0 +1,343 @@
+import { TwitterUserAuth } from './auth-user';
+import { bearerToken } from './api';
+
+describe('TwitterUserAuth', () => {
+  const mockFetch = jest.fn();
+  let auth: TwitterUserAuth;
+
+  // Common login flows
+  const loginFlows = {
+    standard: [
+      'LoginJsInstrumentationSubtask',
+      'LoginEnterUserIdentifierSSO',
+      'LoginEnterPassword',
+      'LoginSuccessSubtask',
+    ],
+    twoFactor: [
+      'LoginJsInstrumentationSubtask',
+      'LoginEnterUserIdentifierSSO',
+      'LoginEnterPassword',
+      'LoginTwoFactorAuthChallenge',
+      'LoginSuccessSubtask',
+    ],
+  };
+
+  // Common mock responses
+  const mockResponses = {
+    guestToken: {
+      ok: true,
+      json: () => Promise.resolve({ guest_token: 'test-guest-token' }),
+      headers: new Headers(),
+    },
+    success: (token: string) => ({
+      ok: true,
+      json: () => Promise.resolve({ flow_token: token }),
+      headers: new Headers(),
+    }),
+    subtask: (token: string, subtaskId: string) => ({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          flow_token: token,
+          subtasks: [{ subtask_id: subtaskId }],
+        }),
+      headers: new Headers(),
+    }),
+    error: (code: number, message: string) => ({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          flow_token: 'error-token',
+          errors: [{ code, message }],
+        }),
+      headers: new Headers(),
+    }),
+    httpError: (status: number, statusText: string, message: string) => ({
+      ok: false,
+      status,
+      statusText,
+      headers: new Headers(),
+      text: () => Promise.resolve(message),
+      json: () => Promise.resolve({ errors: [{ code: status, message }] }),
+    }),
+  };
+
+  // Test utilities
+  const setupAuth = () => {
+    mockFetch.mockReset();
+    return new TwitterUserAuth(bearerToken, {
+      fetch: mockFetch,
+      transform: {},
+      rateLimitStrategy: {
+        onRateLimit: async () => {
+          throw new Error('Rate limit hit');
+        },
+      },
+    });
+  };
+
+  const mockLoginFlow = (subtasks: string[]) => {
+    mockFetch
+      .mockResolvedValueOnce(mockResponses.guestToken)
+      .mockResolvedValueOnce(mockResponses.subtask('token1', subtasks[0]));
+
+    for (let i = 1; i < subtasks.length; i++) {
+      mockFetch.mockResolvedValueOnce(
+        mockResponses.subtask(`token${i + 1}`, subtasks[i]),
+      );
+    }
+    mockFetch.mockResolvedValueOnce(mockResponses.success('final'));
+  };
+
+  const setupAuthenticatedState = async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockResponses.guestToken)
+      .mockResolvedValueOnce(
+        mockResponses.subtask('token1', 'LoginSuccessSubtask'),
+      )
+      .mockResolvedValueOnce(mockResponses.success('final'));
+
+    await auth.login('testuser', 'testpass');
+    mockFetch.mockClear();
+  };
+
+  beforeEach(() => {
+    auth = setupAuth();
+  });
+
+  describe('login', () => {
+    it('should handle successful login flow', async () => {
+      mockLoginFlow(loginFlows.standard);
+      await auth.login('testuser', 'testpass');
+
+      expect(mockFetch).toHaveBeenCalledTimes(6); // Including guest token
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        'https://api.twitter.com/1.1/guest/activate.json',
+      );
+      for (let i = 1; i < mockFetch.mock.calls.length; i++) {
+        expect(mockFetch.mock.calls[i][0]).toBe(
+          'https://api.twitter.com/1.1/onboarding/task.json',
+        );
+      }
+    });
+
+    it('should handle login failure', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponses.guestToken)
+        .mockResolvedValueOnce(mockResponses.error(99, 'Invalid credentials'));
+
+      await expect(auth.login('testuser', 'wrongpass')).rejects.toThrow(
+        'Authentication error (99): Invalid credentials',
+      );
+    });
+
+    it('should handle 2FA challenge', async () => {
+      mockLoginFlow(loginFlows.twoFactor);
+      await auth.login('testuser', 'testpass', undefined, 'JBSWY3DPEHPK3PXP');
+      expect(mockFetch).toHaveBeenCalledTimes(7);
+    });
+
+    it('should retry 2FA challenge after failure', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponses.guestToken)
+        // First 2FA challenge
+        .mockResolvedValueOnce(
+          mockResponses.subtask('token1', 'LoginTwoFactorAuthChallenge'),
+        )
+        // First attempt fails
+        .mockResolvedValueOnce(
+          mockResponses.subtask('token2', 'LoginTwoFactorAuthChallenge'),
+        )
+        // Second attempt succeeds
+        .mockResolvedValueOnce(
+          mockResponses.subtask('token3', 'LoginSuccessSubtask'),
+        )
+        // Final success
+        .mockResolvedValueOnce(mockResponses.success('final'));
+
+      await auth.login('testuser', 'testpass', undefined, 'JBSWY3DPEHPK3PXP');
+      expect(mockFetch).toHaveBeenCalledTimes(5);
+    });
+
+    it('should handle all 2FA attempts failing', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponses.guestToken)
+        .mockResolvedValueOnce(
+          mockResponses.subtask('token1', 'LoginTwoFactorAuthChallenge'),
+        )
+        .mockResolvedValueOnce(mockResponses.error(236, 'Bad 2FA code'))
+        .mockResolvedValueOnce(mockResponses.error(236, 'Bad 2FA code'))
+        .mockResolvedValueOnce(mockResponses.error(236, 'Bad 2FA code'));
+
+      await expect(
+        auth.login('testuser', 'testpass', undefined, 'JBSWY3DPEHPK3PXP'),
+      ).rejects.toThrow('Bad 2FA code');
+    });
+
+    it('should handle missing TOTP secret during 2FA challenge', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponses.guestToken)
+        .mockResolvedValueOnce(
+          mockResponses.subtask('token1', 'LoginTwoFactorAuthChallenge'),
+        );
+
+      await expect(auth.login('testuser', 'testpass')).rejects.toThrow(
+        'Two-factor authentication is required but no secret was provided',
+      );
+    });
+
+    it('should handle invalid TOTP secret during 2FA challenge', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponses.guestToken)
+        .mockResolvedValueOnce(
+          mockResponses.subtask('token1', 'LoginTwoFactorAuthChallenge'),
+        );
+
+      await expect(
+        auth.login('testuser', 'testpass', undefined, 'INVALID_SECRET'),
+      ).rejects.toThrow();
+    });
+
+    it('should handle invalid subtask type', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponses.guestToken)
+        .mockResolvedValueOnce(
+          mockResponses.subtask('token1', 'UnknownSubtask'),
+        );
+
+      await expect(auth.login('testuser', 'testpass')).rejects.toThrow(
+        'Unknown subtask UnknownSubtask',
+      );
+    });
+
+    it('should handle network errors', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponses.guestToken)
+        .mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(auth.login('testuser', 'testpass')).rejects.toThrow(
+        'Network error',
+      );
+    });
+
+    it('should handle invalid response format', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponses.guestToken)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({}),
+          headers: new Headers(),
+        });
+
+      await expect(auth.login('testuser', 'testpass')).rejects.toThrow();
+    });
+
+    it('should handle rate limit errors', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponses.guestToken)
+        .mockResolvedValueOnce(
+          mockResponses.httpError(429, 'Too Many Requests', 'Rate limit hit'),
+        );
+
+      await expect(auth.login('testuser', 'testpass')).rejects.toThrow(
+        'Rate limit hit',
+      );
+    });
+
+    it('should handle unauthorized errors', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponses.guestToken)
+        .mockResolvedValueOnce(
+          mockResponses.httpError(
+            401,
+            'Unauthorized',
+            'Could not authenticate you',
+          ),
+        );
+
+      await expect(auth.login('testuser', 'testpass')).rejects.toThrow(
+        'Could not authenticate you',
+      );
+    });
+  });
+
+  describe('logout', () => {
+    it('should handle successful logout', async () => {
+      await setupAuthenticatedState();
+      mockFetch.mockResolvedValueOnce(mockResponses.success('logout'));
+
+      await auth.logout();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.twitter.com/1.1/account/logout.json',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      );
+
+      expect(auth.hasToken()).toBe(false);
+      expect(
+        await auth.cookieJar().getCookies('https://twitter.com'),
+      ).toHaveLength(0);
+    });
+
+    it('should clear state on network error during logout', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+      await auth.logout();
+
+      expect(auth.hasToken()).toBe(false);
+      expect(
+        await auth.cookieJar().getCookies('https://twitter.com'),
+      ).toHaveLength(0);
+    });
+
+    it('should clear state on failed logout', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponses.httpError(400, 'Bad Request', 'User not found'),
+      );
+
+      await auth.logout();
+
+      expect(auth.hasToken()).toBe(false);
+      expect(
+        await auth.cookieJar().getCookies('https://twitter.com'),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('isLoggedIn', () => {
+    it('should return true when logged in', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponses.success('verify'));
+      const result = await auth.isLoggedIn();
+      expect(result).toBe(true);
+    });
+
+    it('should return false when not logged in', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ errors: [{ code: 99 }] }),
+        headers: new Headers(),
+      });
+
+      const result = await auth.isLoggedIn();
+      expect(result).toBe(false);
+    });
+
+    it('should handle network error during status check', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+      const result = await auth.isLoggedIn();
+      expect(result).toBe(false);
+    });
+
+    it('should handle invalid response during status check', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ errors: [{ code: -1 }] }),
+        headers: new Headers(),
+      });
+
+      const result = await auth.isLoggedIn();
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/auth-user.test.ts
+++ b/src/auth-user.test.ts
@@ -131,6 +131,18 @@ describe('TwitterUserAuth', () => {
       );
     });
 
+    it('should handle DenyLoginSubtask flow', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponses.guestToken)
+        .mockResolvedValueOnce(
+          mockResponses.subtask('token1', 'DenyLoginSubtask'),
+        );
+
+      await expect(auth.login('testuser', 'wrongpass')).rejects.toThrow(
+        'Authentication error: DenyLoginSubtask',
+      );
+    });
+
     it('should handle 2FA challenge', async () => {
       mockLoginFlow(loginFlows.twoFactor);
       await auth.login('testuser', 'testpass', undefined, 'JBSWY3DPEHPK3PXP');

--- a/src/auth-user.ts
+++ b/src/auth-user.ts
@@ -60,6 +60,40 @@ export interface TwitterUserAuthCredentials {
   twoFactorSecret?: string;
 }
 
+/**
+ * The API interface provided to custom subtask handlers for interacting with the Twitter authentication flow.
+ * This interface allows handlers to send flow requests and access the current flow token.
+ *
+ * The API is passed to each subtask handler and provides methods necessary for implementing
+ * custom authentication subtasks. It abstracts away the low-level details of communicating
+ * with Twitter's authentication API.
+ *
+ * @example
+ * ```typescript
+ * import { Scraper, FlowSubtaskHandler } from "@the-convocation/twitter-scraper";
+ *
+ * // A custom subtask handler that implements a hypothetical example subtask
+ * const exampleHandler: FlowSubtaskHandler = async (subtaskId, response, credentials, api) => {
+ *   // Process the example subtask somehow
+ *   const data = await processExampleTask();
+ *
+ *   // Submit the processed data using the provided API
+ *   return await api.sendFlowRequest({
+ *     flow_token: api.getFlowToken(),
+ *     subtask_inputs: [{
+ *       subtask_id: subtaskId,
+ *       example_data: {
+ *         value: data,
+ *         link: "next_link"
+ *       }
+ *     }]
+ *   });
+ * };
+ *
+ * const scraper = new Scraper();
+ * scraper.registerAuthSubtaskHandler("ExampleSubtask", exampleHandler);
+ * ```
+ */
 export interface FlowSubtaskHandlerApi {
   /**
    * Send a flow request to the Twitter API.
@@ -76,6 +110,69 @@ export interface FlowSubtaskHandlerApi {
   getFlowToken: () => string;
 }
 
+/**
+ * A handler function for processing Twitter authentication flow subtasks.
+ * Library consumers can implement and register custom handlers for new or
+ * existing subtask types using the Scraper.registerAuthSubtaskHandler method.
+ *
+ * Each subtask handler is called when its corresponding subtask ID is encountered
+ * during the authentication flow. The handler receives the subtask ID, the previous
+ * response data, the user's credentials, and an API interface for interacting with
+ * the authentication flow.
+ *
+ * Handlers should process their specific subtask and return either a successful response
+ * or an error. Success responses typically lead to the next subtask in the flow, while
+ * errors will halt the authentication process.
+ *
+ * @param subtaskId - The identifier of the subtask being handled
+ * @param previousResponse - The complete response from the previous authentication flow step
+ * @param credentials - The user's authentication credentials including username, password, etc.
+ * @param api - An interface providing methods to interact with the authentication flow
+ * @returns A promise resolving to either a successful flow response or an error
+ *
+ * @example
+ * ```typescript
+ * import { Scraper, FlowSubtaskHandler } from "@the-convocation/twitter-scraper";
+ *
+ * // Custom handler for a hypothetical verification subtask
+ * const verificationHandler: FlowSubtaskHandler = async (
+ *   subtaskId,
+ *   response,
+ *   credentials,
+ *   api
+ * ) => {
+ *   // Extract the verification data from the response
+ *   const verificationData = response.subtasks?.[0].exampleData?.value;
+ *   if (!verificationData) {
+ *     return {
+ *       status: 'error',
+ *       err: new Error('No verification data found in response')
+ *     };
+ *   }
+ *
+ *   // Process the verification data somehow
+ *   const result = await processVerification(verificationData);
+ *
+ *   // Submit the result using the flow API
+ *   return await api.sendFlowRequest({
+ *     flow_token: api.getFlowToken(),
+ *     subtask_inputs: [{
+ *       subtask_id: subtaskId,
+ *       example_verification: {
+ *         value: result,
+ *         link: "next_link"
+ *       }
+ *     }]
+ *   });
+ * };
+ *
+ * const scraper = new Scraper();
+ * scraper.registerAuthSubtaskHandler("ExampleVerificationSubtask", verificationHandler);
+ *
+ * // Later, when logging in...
+ * await scraper.login("username", "password");
+ * ```
+ */
 export type FlowSubtaskHandler = (
   subtaskId: string,
   previousResponse: TwitterUserAuthFlowResponse,

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,6 +8,7 @@ import {
   RateLimitStrategy,
   WaitingRateLimitStrategy,
 } from './rate-limit';
+import { AuthenticationError } from './errors';
 
 export interface TwitterAuthOptions {
   fetch: typeof fetch;
@@ -169,7 +170,9 @@ export class TwitterGuestAuth implements TwitterAuth {
 
     const token = this.guestToken;
     if (token == null) {
-      throw new Error('Authentication token is null or undefined.');
+      throw new AuthenticationError(
+        'Authentication token is null or undefined.',
+      );
     }
 
     headers.set('authorization', `Bearer ${this.bearerToken}`);
@@ -232,17 +235,17 @@ export class TwitterGuestAuth implements TwitterAuth {
     await updateCookieJar(this.jar, res.headers);
 
     if (!res.ok) {
-      throw new Error(await res.text());
+      throw new AuthenticationError(await res.text());
     }
 
     const o = await res.json();
     if (o == null || o['guest_token'] == null) {
-      throw new Error('guest_token not found.');
+      throw new AuthenticationError('guest_token not found.');
     }
 
     const newGuestToken = o['guest_token'];
     if (typeof newGuestToken !== 'string') {
-      throw new Error('guest_token was not a string.');
+      throw new AuthenticationError('guest_token was not a string.');
     }
 
     this.guestToken = newGuestToken;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -22,6 +22,13 @@ export class ApiError extends Error {
   }
 }
 
+export class AuthenticationError extends Error {
+  constructor(message?: string) {
+    super(message || 'Authentication failed');
+    this.name = 'AuthenticationError';
+  }
+}
+
 interface Position {
   line: number;
   column: number;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -29,26 +29,26 @@ export class AuthenticationError extends Error {
   }
 }
 
-interface Position {
+export interface TwitterApiErrorPosition {
   line: number;
   column: number;
 }
 
-interface TraceInfo {
+export interface TwitterApiErrorTraceInfo {
   trace_id: string;
 }
 
-interface TwitterApiErrorExtensions {
+export interface TwitterApiErrorExtensions {
   code?: number;
   kind?: string;
   name?: string;
   source?: string;
-  tracing?: TraceInfo;
+  tracing?: TwitterApiErrorTraceInfo;
 }
 
 export interface TwitterApiErrorRaw extends TwitterApiErrorExtensions {
   message?: string;
-  locations?: Position[];
+  locations?: TwitterApiErrorPosition[];
   path?: string[];
   extensions?: TwitterApiErrorExtensions;
 }

--- a/src/relationships.ts
+++ b/src/relationships.ts
@@ -1,6 +1,6 @@
 import { addApiFeatures, requestApi } from './api';
 import { TwitterAuth } from './auth';
-import { Profile, getUserIdByScreenName } from './profile';
+import { Profile } from './profile';
 import { QueryProfilesResponse } from './timeline-v1';
 import { getUserTimeline } from './timeline-async';
 import {
@@ -8,6 +8,7 @@ import {
   parseRelationshipTimeline,
 } from './timeline-relationship';
 import stringify from 'json-stable-stringify';
+import { AuthenticationError } from './errors';
 
 export function getFollowing(
   userId: string,
@@ -35,6 +36,12 @@ export async function fetchProfileFollowing(
   auth: TwitterAuth,
   cursor?: string,
 ): Promise<QueryProfilesResponse> {
+  if (!(await auth.isLoggedIn())) {
+    throw new AuthenticationError(
+      'Scraper is not logged-in for profile following.',
+    );
+  }
+
   const timeline = await getFollowingTimeline(
     userId,
     maxProfiles,
@@ -51,6 +58,12 @@ export async function fetchProfileFollowers(
   auth: TwitterAuth,
   cursor?: string,
 ): Promise<QueryProfilesResponse> {
+  if (!(await auth.isLoggedIn())) {
+    throw new AuthenticationError(
+      'Scraper is not logged-in for profile followers.',
+    );
+  }
+
   const timeline = await getFollowersTimeline(
     userId,
     maxProfiles,
@@ -68,7 +81,9 @@ async function getFollowingTimeline(
   cursor?: string,
 ): Promise<RelationshipTimeline> {
   if (!auth.isLoggedIn()) {
-    throw new Error('Scraper is not logged-in for profile following.');
+    throw new AuthenticationError(
+      'Scraper is not logged-in for profile following.',
+    );
   }
 
   if (maxItems > 50) {
@@ -116,7 +131,9 @@ async function getFollowersTimeline(
   cursor?: string,
 ): Promise<RelationshipTimeline> {
   if (!auth.isLoggedIn()) {
-    throw new Error('Scraper is not logged-in for profile followers.');
+    throw new AuthenticationError(
+      'Scraper is not logged-in for profile followers.',
+    );
   }
 
   if (maxItems > 50) {

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -1,7 +1,7 @@
 import { Cookie } from 'tough-cookie';
 import { bearerToken, FetchTransformOptions, RequestApiResult } from './api';
 import { TwitterAuth, TwitterAuthOptions, TwitterGuestAuth } from './auth';
-import { TwitterUserAuth } from './auth-user';
+import { FlowSubtaskHandler, TwitterUserAuth } from './auth-user';
 import { getProfile, getUserIdByScreenName, Profile } from './profile';
 import {
   fetchSearchProfiles,
@@ -74,6 +74,25 @@ export class Scraper {
   constructor(private readonly options?: Partial<ScraperOptions>) {
     this.token = bearerToken;
     this.useGuestAuth();
+  }
+
+  /**
+   * Registers a subtask handler for the given subtask ID. This
+   * will override any existing handler for the same subtask.
+   * @param subtaskId The ID of the subtask to register the handler for.
+   * @param subtaskHandler The handler function to register.
+   */
+  public registerAuthSubtaskHandler(
+    subtaskId: string,
+    subtaskHandler: FlowSubtaskHandler,
+  ): void {
+    if (this.auth instanceof TwitterUserAuth) {
+      this.auth.registerSubtaskHandler(subtaskId, subtaskHandler);
+    }
+
+    if (this.authTrends instanceof TwitterUserAuth) {
+      this.authTrends.registerSubtaskHandler(subtaskId, subtaskHandler);
+    }
   }
 
   /**

--- a/src/search.ts
+++ b/src/search.ts
@@ -10,6 +10,7 @@ import {
   parseSearchTimelineUsers,
 } from './timeline-search';
 import stringify from 'json-stable-stringify';
+import { AuthenticationError } from './errors';
 
 /**
  * The categories that can be used in Twitter searches.
@@ -85,8 +86,8 @@ async function getSearchTimeline(
   auth: TwitterAuth,
   cursor?: string,
 ): Promise<SearchTimeline> {
-  if (!auth.isLoggedIn()) {
-    throw new Error('Scraper is not logged-in for search.');
+  if (!(await auth.isLoggedIn())) {
+    throw new AuthenticationError('Scraper is not logged-in for search.');
   }
 
   if (maxItems > 50) {

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -13,6 +13,7 @@ import {
 import { getTweetTimeline } from './timeline-async';
 import { apiRequestFactory } from './api-data';
 import { ListTimeline, parseListTimelineTweets } from './timeline-list';
+import { AuthenticationError } from './errors';
 
 export interface Mention {
   id: string;
@@ -256,8 +257,10 @@ export async function fetchLikedTweets(
   cursor: string | undefined,
   auth: TwitterAuth,
 ): Promise<QueryTweetsResponse> {
-  if (!auth.isLoggedIn()) {
-    throw new Error('Scraper is not logged-in for fetching liked tweets.');
+  if (!(await auth.isLoggedIn())) {
+    throw new AuthenticationError(
+      'Scraper is not logged-in for fetching liked tweets.',
+    );
   }
 
   if (maxTweets > 200) {


### PR DESCRIPTION
Implements support for registering custom auth subtasks, particularly so that consumers can handle the `ArkoseLogin` subtask however is most appropriate for their target platform ([examples](https://github.com/search?q=ArkoseLogin&type=code)). The API also permits overriding existing subtasks, in the event that consumers want to replace any of the existing implementation.

The subtask handler API is shown below:
```ts
type FlowSubtaskHandler = (subtaskId: string, previousResponse: TwitterUserAuthFlowResponse, credentials: TwitterUserAuthCredentials, api: FlowSubtaskHandlerApi) => Promise<FlowTokenResult>;

interface FlowSubtaskHandlerApi {
  /**
   * Send a flow request to the Twitter API.
   * @param request The request object containing flow token and subtask inputs
   * @returns The result of the flow task
   */
  sendFlowRequest: (request: TwitterUserAuthFlowRequest) => Promise<FlowTokenResult>;
  /**
   * Gets the current flow token.
   * @returns The current flow token
   */
  getFlowToken: () => string;
}
```

This can then be used like so:
```ts
const arkoseLoginHandler: FlowSubtaskHandler = async (subtaskId, previousResponse, credentials, api) => {
  const subtaskInputs = await /* whatever handling is needed */;
  return await api.sendFlowRequest({
    flow_token: api.getFlowToken(),
    subtask_inputs: subtaskInputs,
  });
};

scraper.registerAuthSubtaskHandler('ArkoseLogin', arkoseLoginHandler);
```

---

Mitigation for #114.