### PR TITLE
Fix missing  edit_control?.edit_control_initial on parseLegacyTweet

### DIFF
--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -224,6 +224,7 @@ export function parseLegacyTweet(
         retweetedStatusResult?.core?.user_results?.result?.core,
         retweetedStatusResult?.core?.user_results?.result?.legacy,
         retweetedStatusResult?.legacy,
+        retweetedStatusResult?.edit_control?.edit_control_initial
       );
 
       if (parsedResult.success) {
@@ -264,6 +265,7 @@ function parseResult(result?: TimelineResultRaw): ParseTweetResult {
     result?.core?.user_results?.result?.core,
     result?.core?.user_results?.result?.legacy,
     result?.legacy,
+    result?.edit_control?.edit_control_initial
   );
   if (!tweetResult.success) {
     return tweetResult;


### PR DESCRIPTION
The fields edit_control_initial was missing from some parseLegacyTweet function call

This probably need test