### PR TITLE
Fix: isEdited was always false if tweet was edited only once

### DIFF
--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -151,7 +151,6 @@ export function parseLegacyTweet(
 
   // The edit tweets array always contains the original tweet, even if it has not been edited
   const tweetVersions = editControl?.edit_tweet_ids ?? [tweetId];
-  const editIds = tweetVersions.filter((id) => id !== tweetId);
 
   const name = user.name ?? coreUser?.name;
   const username = user.screen_name ?? coreUser?.screen_name;
@@ -184,7 +183,7 @@ export function parseLegacyTweet(
     videos,
     isQuoted: false,
     isReply: false,
-    isEdited: editIds.length > 1,
+    isEdited: tweetVersions.length > 1,
     versions: tweetVersions,
     isRetweet: false,
     isPin: false,


### PR DESCRIPTION
isEdited was always false if tweet was edited only once because editsIds contains only the edited tweet id
Remove editsIds and use tweetVersions, length need to be > 1 because original tweet id is always present

Exemple : This tweet was flag to not edited but it contain more 1 edit (the original tweet) https://x.com/DOFUSfr/status/1925960820732592438