### PR TITLE
Parse user pinned tweets correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "scraper",
     "crawler"
   ],
-  "version": "0.16.5",
+  "version": "0.16.6",
   "main": "dist/default/cjs/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {

--- a/src/timeline-v1.ts
+++ b/src/timeline-v1.ts
@@ -96,6 +96,7 @@ export interface TimelineResultRaw {
   core?: {
     user_results?: {
       result?: {
+        __typename?: string;
         is_blue_verified?: boolean;
         core?: CoreUserRaw;
         legacy?: LegacyUserRaw;

--- a/src/timeline-v2.test.ts
+++ b/src/timeline-v2.test.ts
@@ -1,0 +1,97 @@
+import { TimelineV2, parseTimelineTweetsV2 } from './timeline-v2';
+
+test('parseTimelineTweetsV2 handles pinned tweets correctly', async () => {
+  const data: TimelineV2 = {
+    data: {
+      user: {
+        result: {
+          __typename: 'User',
+          timeline: {
+            timeline: {
+              instructions: [
+                {
+                  type: 'TimelinePinEntry',
+                  entry: {
+                    entryId: 'tweet-1',
+                    content: {
+                      entryType: 'TimelineTimelineItem',
+                      __typename: 'TimelineTimelineItem',
+                      itemContent: {
+                        itemType: 'TimelineTweet',
+                        __typename: 'TimelineTweet',
+                        tweet_results: {
+                          result: {
+                            __typename: 'Tweet',
+                            rest_id: '1',
+                            core: {
+                              user_results: {
+                                result: {
+                                  core: {
+                                    created_at:
+                                      'Tue Oct 13 15:48:33 +0000 2015',
+                                    name: 'DOFUS Touch',
+                                    screen_name: 'DofusTouch',
+                                  },
+                                  legacy: {
+                                    pinned_tweet_ids_str: ['1'],
+                                  },
+                                },
+                              },
+                            },
+                            legacy: {
+                              created_at: 'Mon Jan 1 12:00:00 +0000 2025',
+                              conversation_id_str: '1',
+                              entities: {},
+                              favorite_count: 32,
+                              full_text: 'test',
+                              reply_count: 21,
+                              retweet_count: 4,
+                              user_id_str: '1',
+                              id_str: '1',
+                            },
+                          },
+                        },
+                        tweetDisplayType: 'Tweet',
+                      },
+                    },
+                  },
+                },
+                {
+                  type: 'TimelineAddEntries',
+                  entries: [
+                    {
+                      entryId: 'cursor-top-2',
+                      content: {
+                        entryType: 'TimelineTimelineCursor',
+                        __typename: 'TimelineTimelineCursor',
+                        value: 'A',
+                        cursorType: 'Top',
+                      },
+                    },
+                    {
+                      entryId: 'cursor-bottom-3',
+                      content: {
+                        entryType: 'TimelineTimelineCursor',
+                        __typename: 'TimelineTimelineCursor',
+                        value: 'B',
+                        cursorType: 'Bottom',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const result = parseTimelineTweetsV2(data);
+  expect(result.tweets.length).toBe(1);
+  expect(result.tweets[0].id).toBe('1');
+  expect(result.tweets[0].isPin).toBe(true);
+  expect(result.previous).toBe('A');
+  expect(result.next).toBe('B');
+  expect(result.tweets[0].text).toBe('test');
+});

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -19,6 +19,7 @@ export interface TimelineUserResultRaw {
 
 export interface TimelineEntryItemContentRaw {
   itemType?: string;
+  __typename?: string;
   tweetDisplayType?: string;
   tweetResult?: {
     result?: TimelineResultRaw;
@@ -35,6 +36,8 @@ export interface TimelineEntryItemContentRaw {
 export interface TimelineEntryRaw {
   entryId: string;
   content?: {
+    entryType?: string;
+    __typename?: string;
     cursorType?: string;
     value?: string;
     items?: {
@@ -86,6 +89,7 @@ export interface TimelineV2 {
   data?: {
     user?: {
       result?: {
+        __typename?: string;
         timeline?: {
           timeline?: {
             instructions?: TimelineInstruction[];
@@ -294,6 +298,16 @@ function parseResult(result?: TimelineResultRaw): ParseTweetResult {
 
 const expectedEntryTypes = ['tweet', 'profile-conversation'];
 
+function getTimelineInstructionEntries(
+  instruction: TimelineInstruction,
+): TimelineEntryRaw[] {
+  const entries = instruction.entries ?? [];
+  if (instruction.entry) {
+    entries.push(instruction.entry);
+  }
+  return entries;
+}
+
 export function parseTimelineTweetsV2(
   timeline: TimelineV2,
 ): QueryTweetsResponse {
@@ -303,8 +317,7 @@ export function parseTimelineTweetsV2(
   const instructions =
     timeline.data?.user?.result?.timeline?.timeline?.instructions ?? [];
   for (const instruction of instructions) {
-    const entries = instruction.entries ?? [];
-
+    const entries = getTimelineInstructionEntries(instruction);
     for (const entry of entries) {
       const entryContent = entry.content;
       if (!entryContent) continue;
@@ -402,7 +415,7 @@ export function parseThreadedConversation(
     [];
 
   for (const instruction of instructions) {
-    const entries = instruction.entries ?? [];
+    const entries = getTimelineInstructionEntries(instruction);
     for (const entry of entries) {
       const entryContent = entry.content?.itemContent;
       if (entryContent) {


### PR DESCRIPTION
Pinned tweets come in an instruction under an `entry` key, not an `entries` key like regular tweets, so they were getting silently ignored. This PR collapses single entry instructions into the full instruction list we consume.

Fixes #135.