### PR TITLE
feat: add article parsing and handling to timeline and scraper modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,11 @@
   "packageManager": "yarn@1.22.19",
   "scripts": {
     "build": "rimraf dist && rollup -c",
-    "prepare": "yarn install & yarn build",
     "commit": "cz",
     "docs:generate": "typedoc --options typedoc.json",
     "docs:deploy": "yarn docs:generate && gh-pages -d docs",
     "format": "prettier --write src/**/*.ts",
-    "prepare": "husky install",
+    "prepare": "husky install && yarn build",
     "test": "jest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "packageManager": "yarn@1.22.19",
   "scripts": {
     "build": "rimraf dist && rollup -c",
-    "prepare": "yarn build",
+    "prepare": "yarn install & yarn build",
     "commit": "cz",
     "docs:generate": "typedoc --options typedoc.json",
     "docs:deploy": "yarn docs:generate && gh-pages -d docs",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "packageManager": "yarn@1.22.19",
   "scripts": {
     "build": "rimraf dist && rollup -c",
+    "prepare": "yarn build",
     "commit": "cz",
     "docs:generate": "typedoc --options typedoc.json",
     "docs:deploy": "yarn docs:generate && gh-pages -d docs",

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -480,36 +480,10 @@ export class Scraper {
    * Set cookies for the current session.
    * @param cookies The cookies to set for the current session.
    */
-  public async setCookies(cookies: (string | Cookie | any)[]): Promise<void> {
+  public async setCookies(cookies: (string | Cookie)[]): Promise<void> {
     const userAuth = new TwitterUserAuth(this.token, this.getAuthOptions());
     for (const cookie of cookies) {
-      let cookieToSet: string | Cookie;
-      
-      // If it's a plain object (from JSON.parse), convert it to a Cookie instance
-      if (typeof cookie === 'object' && cookie !== null && !(cookie instanceof Cookie) && typeof cookie !== 'string') {
-        // Fix domain issue and name/key property issue
-        const cookieData = { ...cookie };
-        if (cookieData.domain && cookieData.domain.startsWith('.x.com')) {
-          cookieData.domain = 'x.com';
-        }
-        // tough-cookie expects 'key' property, but browser cookies use 'name'
-        if (cookieData.name && !cookieData.key) {
-          cookieData.key = cookieData.name;
-          delete cookieData.name;
-        }
-        
-        const parsedCookie = Cookie.fromJSON(cookieData);
-        if (parsedCookie) {
-          cookieToSet = parsedCookie;
-        } else {
-          console.warn('Failed to parse cookie:', cookie);
-          continue;
-        }
-      } else {
-        cookieToSet = cookie;
-      }
-      
-      await userAuth.cookieJar().setCookie(cookieToSet, twUrl);
+      await userAuth.cookieJar().setCookie(cookie, twUrl);
     }
 
     this.auth = userAuth;

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -480,10 +480,36 @@ export class Scraper {
    * Set cookies for the current session.
    * @param cookies The cookies to set for the current session.
    */
-  public async setCookies(cookies: (string | Cookie)[]): Promise<void> {
+  public async setCookies(cookies: (string | Cookie | any)[]): Promise<void> {
     const userAuth = new TwitterUserAuth(this.token, this.getAuthOptions());
     for (const cookie of cookies) {
-      await userAuth.cookieJar().setCookie(cookie, twUrl);
+      let cookieToSet: string | Cookie;
+      
+      // If it's a plain object (from JSON.parse), convert it to a Cookie instance
+      if (typeof cookie === 'object' && cookie !== null && !(cookie instanceof Cookie) && typeof cookie !== 'string') {
+        // Fix domain issue and name/key property issue
+        const cookieData = { ...cookie };
+        if (cookieData.domain && cookieData.domain.startsWith('.x.com')) {
+          cookieData.domain = 'x.com';
+        }
+        // tough-cookie expects 'key' property, but browser cookies use 'name'
+        if (cookieData.name && !cookieData.key) {
+          cookieData.key = cookieData.name;
+          delete cookieData.name;
+        }
+        
+        const parsedCookie = Cookie.fromJSON(cookieData);
+        if (parsedCookie) {
+          cookieToSet = parsedCookie;
+        } else {
+          console.warn('Failed to parse cookie:', cookie);
+          continue;
+        }
+      } else {
+        cookieToSet = cookie;
+      }
+      
+      await userAuth.cookieJar().setCookie(cookieToSet, twUrl);
     }
 
     this.auth = userAuth;

--- a/src/timeline-v1.ts
+++ b/src/timeline-v1.ts
@@ -85,6 +85,7 @@ export interface SearchResultRaw {
     result?: SearchResultRaw;
   };
   legacy?: LegacyTweetRaw;
+  article?: ArticleRaw;
 }
 
 export interface TimelineResultRaw {
@@ -118,6 +119,79 @@ export interface TimelineResultRaw {
   };
   legacy?: LegacyTweetRaw;
   tweet?: TimelineResultRaw;
+  article?: ArticleRaw;
+}
+
+export interface ArticleRaw {
+  article_results: {
+    result: ArticleResultRaw;
+  };
+}
+
+export interface ArticleResultRaw {
+  rest_id: string;
+  title: string;
+  cover_media?: ArticleCoverMediaRaw;
+  content_state: ArticleContentStateRaw;
+  media_entities?: ArticleMediaEntityRaw[];
+}
+
+export interface ArticleCoverMediaRaw {
+  media_key: string;
+  media_info: {
+    original_img_url: string;
+  };
+}
+
+export interface ArticleContentStateRaw {
+  blocks: ArticleBlockRaw[];
+  entityMap: ArticleEntityRaw[];
+}
+
+export interface ArticleBlockRaw {
+  key: string;
+  text: string;
+  type: string;
+  inlineStyleRanges: {
+    offset: number;
+    length: number;
+    style: string;
+  }[];
+  entityRanges: {
+    key: number;
+    offset: number;
+    length: number;
+  }[];
+}
+
+export interface ArticleEntityValueMediaItemRaw {
+  localMediaId: string;
+  mediaCategory: string;
+  mediaId: string;
+}
+
+export interface ArticleEntityValueRaw {
+  type: string;
+  mutability?: string;
+  data: {
+    url?: string;
+    entityKey?: string;
+    mediaItems?: ArticleEntityValueMediaItemRaw[];
+  };
+}
+
+export interface ArticleEntityRaw {
+  key: number;
+  value: ArticleEntityValueRaw;
+}
+
+export interface ArticleMediaEntityRaw {
+  media_key: string;
+  media_id: string;
+  media_info: {
+    __typename: 'ApiImage' | 'ApiGif' | 'ApiVideo';
+    original_img_url: string;
+  };
 }
 
 export interface LegacyTweetRaw {

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -419,8 +419,10 @@ function parseResult(result?: TimelineResultRaw): ParseTweetResult {
   const articleRaw = result?.article?.article_results?.result;
   if (articleRaw) {
     tweetResult.tweet.isArticle = true;
-    tweetResult.tweet.article = parseArticle(articleRaw);
-    tweetResult.tweet.text = parseArticleToMarkdown(articleRaw);
+    if (articleRaw.content_state) {
+      tweetResult.tweet.article = parseArticle(articleRaw);
+      tweetResult.tweet.text = parseArticleToMarkdown(articleRaw);
+    }
   }
 
   const quotedResult = result?.quoted_status_result?.result;

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -1,6 +1,8 @@
 import { CoreUserRaw, LegacyUserRaw } from './profile';
 import { parseMediaGroups, reconstructTweetHtml } from './timeline-tweet-util';
 import {
+  ArticleEntityValueMediaItemRaw,
+  ArticleResultRaw,
   EditControlInitialRaw,
   LegacyTweetRaw,
   ParseTweetResult,
@@ -8,7 +10,7 @@ import {
   SearchResultRaw,
   TimelineResultRaw,
 } from './timeline-v1';
-import { Tweet } from './tweets';
+import { Article, Tweet } from './tweets';
 import { isFieldDefined } from './type-util';
 
 export interface TimelineUserResultRaw {
@@ -256,6 +258,139 @@ export function parseLegacyTweet(
   return { success: true, tweet: tw };
 }
 
+function parseArticleToMarkdown(article: Readonly<ArticleResultRaw>): string {
+  const { blocks, entityMap } = article.content_state;
+  let markdown = `# ${article.title}\\n\\n`;
+
+  for (const block of blocks) {
+    let text = block.text;
+
+    const sortedEntityRanges = [...block.entityRanges].sort(
+      (a, b) => b.offset - a.offset,
+    ); // Reverse order to prevent messing up the offsets
+    for (const range of sortedEntityRanges) {
+      const entityWrapper = entityMap.find(
+        (e) => String(e.key) === String(range.key),
+      );
+      if (!entityWrapper) continue;
+      const entity = entityWrapper.value;
+
+      const chars = Array.from(text);
+      const originalText = chars
+        .slice(range.offset, range.offset + range.length)
+        .join('');
+      let replacement = originalText;
+
+      let textToWrap = originalText;
+      let trailingNewline = '';
+
+      if (textToWrap.endsWith('\n')) {
+        textToWrap = textToWrap.slice(0, -1);
+        trailingNewline = '\n';
+      }
+
+      if (entity.type === 'LINK' && entity.data.url) {
+        replacement = `[${textToWrap}](${entity.data.url})${trailingNewline}`;
+      }
+
+      const prefix = chars.slice(0, range.offset).join('');
+      const suffix = chars.slice(range.offset + range.length).join('');
+      text = prefix + replacement + suffix;
+    }
+
+    const sortedStyleRanges = [...block.inlineStyleRanges].sort(
+      (a, b) => b.offset - a.offset,
+    );
+    for (const range of sortedStyleRanges) {
+      const chars = Array.from(text);
+      const originalText = chars
+        .slice(range.offset, range.offset + range.length)
+        .join('');
+      let replacement = originalText;
+
+      let textToWrap = originalText;
+      let trailingNewline = '';
+
+      if (textToWrap.endsWith('\n')) {
+        textToWrap = textToWrap.slice(0, -1);
+        trailingNewline = '\n';
+      }
+
+      if (range.style.toLowerCase() === 'bold') {
+        replacement = `**${textToWrap}**${trailingNewline}`;
+      } else if (range.style.toLowerCase() === 'italic') {
+        replacement = `*${textToWrap}*${trailingNewline}`;
+      }
+
+      const prefix = chars.slice(0, range.offset).join('');
+      const suffix = chars.slice(range.offset + range.length).join('');
+      text = prefix + replacement + suffix;
+    }
+
+    switch (block.type) {
+      case 'header-one':
+        markdown += `# ${text}\\n\\n`;
+        break;
+      case 'header-two':
+        markdown += `## ${text}\\n\\n`;
+        break;
+      case 'unordered-list-item':
+        markdown += `* ${text}\\n`;
+        break;
+      case 'atomic':
+        for (const range of block.entityRanges) {
+          const entityWrapper = entityMap.find(
+            (e) => String(e.key) === String(range.key),
+          );
+          if (!entityWrapper) continue;
+          const entity = entityWrapper.value;
+          if (entity?.type === 'MEDIA' && entity.data.mediaItems) {
+            for (const mediaItem of entity.data.mediaItems) {
+              if (mediaItem?.mediaId) {
+                const mediaEntity = article.media_entities?.find(
+                  (m) => m.media_id === mediaItem.mediaId,
+                );
+                if (mediaEntity) {
+                  markdown += `![image](${mediaEntity.media_info.original_img_url})\\n\\n`;
+                }
+              }
+            }
+          }
+        }
+        break;
+      case 'unstyled':
+      default:
+        markdown += `${text}\\n\\n`;
+        break;
+    }
+  }
+
+  return markdown.trim();
+}
+
+function parseArticle(articleRaw: Readonly<ArticleResultRaw>): Article {
+  const article: Article = {
+    id: articleRaw.rest_id,
+    title: articleRaw.title,
+    blocks: articleRaw.content_state.blocks,
+  };
+
+  if (articleRaw.cover_media) {
+    const coverMedia = articleRaw.media_entities?.find(
+      (m) => m.media_key === articleRaw.cover_media?.media_key,
+    );
+    if (coverMedia) {
+      article.cover = {
+        id: coverMedia.media_id,
+        url: coverMedia.media_info.original_img_url,
+        alt_text: undefined, // not available
+      };
+    }
+  }
+
+  return article;
+}
+
 function parseResult(result?: TimelineResultRaw): ParseTweetResult {
   const noteTweetResultText =
     result?.note_tweet?.note_tweet_results?.result?.text;
@@ -279,6 +414,13 @@ function parseResult(result?: TimelineResultRaw): ParseTweetResult {
     if (!isNaN(views)) {
       tweetResult.tweet.views = views;
     }
+  }
+
+  const articleRaw = result?.article?.article_results?.result;
+  if (articleRaw) {
+    tweetResult.tweet.isArticle = true;
+    tweetResult.tweet.article = parseArticle(articleRaw);
+    tweetResult.tweet.text = parseArticleToMarkdown(articleRaw);
   }
 
   const quotedResult = result?.quoted_status_result?.result;

--- a/src/timeline-v2.ts
+++ b/src/timeline-v2.ts
@@ -372,7 +372,7 @@ function parseArticle(articleRaw: Readonly<ArticleResultRaw>): Article {
   const article: Article = {
     id: articleRaw.rest_id,
     title: articleRaw.title,
-    blocks: articleRaw.content_state.blocks,
+    content_state: articleRaw.content_state,
   };
 
   if (articleRaw.cover_media) {

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -2,7 +2,7 @@ import { addApiFeatures, requestApi } from './api';
 import { TwitterAuth } from './auth';
 import { getUserIdByScreenName } from './profile';
 import {
-  ArticleBlockRaw,
+  ArticleContentStateRaw,
   LegacyTweetRaw,
   QueryTweetsResponse,
 } from './timeline-v1';
@@ -41,7 +41,7 @@ export interface Article {
   id: string;
   title: string;
   cover?: Photo;
-  blocks: ArticleBlockRaw[];
+  content_state: ArticleContentStateRaw;
 }
 
 export interface PlaceRaw {

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -1,7 +1,11 @@
 import { addApiFeatures, requestApi } from './api';
 import { TwitterAuth } from './auth';
 import { getUserIdByScreenName } from './profile';
-import { LegacyTweetRaw, QueryTweetsResponse } from './timeline-v1';
+import {
+  ArticleBlockRaw,
+  LegacyTweetRaw,
+  QueryTweetsResponse,
+} from './timeline-v1';
 import {
   parseTimelineTweetsV2,
   TimelineV2,
@@ -31,6 +35,13 @@ export interface Video {
   id: string;
   preview: string;
   url?: string;
+}
+
+export interface Article {
+  id: string;
+  title: string;
+  cover?: Photo;
+  blocks: ArticleBlockRaw[];
 }
 
 export interface PlaceRaw {
@@ -65,6 +76,8 @@ export interface Tweet {
   isReply?: boolean;
   isRetweet?: boolean;
   isSelfThread?: boolean;
+  isArticle?: boolean;
+  article?: Article;
   likes?: number;
   name?: string;
   mentions: Mention[];


### PR DESCRIPTION
This pull request introduces support for handling articles within the timeline data structure. It includes changes to add new interfaces for articles, parse article data into markdown, and integrate articles into existing tweet parsing functionality.

### Article Support Enhancements:

* **New Interfaces for Articles**:
  - Added `ArticleRaw`, `ArticleResultRaw`, `ArticleContentStateRaw`, and related interfaces to represent article data, including metadata, media, and content state. (`src/timeline-v1.ts`, [src/timeline-v1.tsR122-R194](diffhunk://#diff-56c9b168ea859b2344cc8faccd482c0a4ba53546fa2dff12a66d792af26facecR122-R194))
  - Updated `SearchResultRaw` and `TimelineResultRaw` to include an optional `article` field for article data. (`src/timeline-v1.ts`, [[1]](diffhunk://#diff-56c9b168ea859b2344cc8faccd482c0a4ba53546fa2dff12a66d792af26facecR88) [[2]](diffhunk://#diff-56c9b168ea859b2344cc8faccd482c0a4ba53546fa2dff12a66d792af26facecR122-R194)

* **Article Parsing Logic**:
  - Implemented `parseArticleToMarkdown` to convert article content into markdown format, handling text, links, styles, headers, lists, and media. (`src/timeline-v2.ts`, [src/timeline-v2.tsR261-R393](diffhunk://#diff-76532b92ab14c3f45a6d1c13bc3f789b56181bad3ac375edbcd64737cbc7030bR261-R393))
  - Added `parseArticle` function to map raw article data to the new `Article` interface, including extracting cover media details. (`src/timeline-v2.ts`, [src/timeline-v2.tsR261-R393](diffhunk://#diff-76532b92ab14c3f45a6d1c13bc3f789b56181bad3ac375edbcd64737cbc7030bR261-R393))

* **Integration with Timeline Parsing**:
  - Updated `parseResult` to detect and process articles within timeline results, converting them to markdown and integrating them into the `Tweet` structure. (`src/timeline-v2.ts`, [src/timeline-v2.tsR419-R425](diffhunk://#diff-76532b92ab14c3f45a6d1c13bc3f789b56181bad3ac375edbcd64737cbc7030bR419-R425))

### Tweet Interface Updates:

* **Support for Articles in Tweets**:
  - Extended the `Tweet` interface to include `isArticle` and `article` fields, enabling tweets to reference associated article data. (`src/tweets.ts`, [src/tweets.tsR79-R80](diffhunk://#diff-2f174dda702815c6cb51e28fb3195e902df20bf40ac78861eeea8f7c08f762d5R79-R80))
  - Added a new `Article` interface to define the structure of article data within tweets. (`src/tweets.ts`, [src/tweets.tsR40-R46](diffhunk://#diff-2f174dda702815c6cb51e28fb3195e902df20bf40ac78861eeea8f7c08f762d5R40-R46))