### PR TITLE
support animated_gif on parseMediaGroups

### DIFF
--- a/src/timeline-tweet-util.ts
+++ b/src/timeline-tweet-util.ts
@@ -25,7 +25,7 @@ export function parseMediaGroups(media: TimelineMediaExtendedRaw[]): {
         url: m.media_url_https,
         alt_text: m.ext_alt_text,
       });
-    } else if (m.type === 'video') {
+    } else if (m.type === 'video' || m.type === 'animated_gif') {
       videos.push(parseVideo(m));
     }
 


### PR DESCRIPTION
Hi,

This PR add the support of `animated_gif`, this allows to have the .mp4 url of the video in the [`videos`](https://github.com/the-convocation/twitter-scraper/blob/89ae341db23b67485b7a6bd7cd7f8fcba5ad8a65/src/tweets.ts#L30) array.

On [this](https://x.com/DOFUSfr/status/1947627689285673423) tweet, [this](https://video.twimg.com/tweet_video/GwdbuOGX0AEuVrj.mp4) video is added.

`animated_gif` works exactly the same as `videos`, so, we can use `parseVideo` to handle it