### PR TITLE
Fix gif parsing to correctly get the .mp4 url

### DIFF
--- a/src/timeline-tweet-util.ts
+++ b/src/timeline-tweet-util.ts
@@ -25,8 +25,10 @@ export function parseMediaGroups(media: TimelineMediaExtendedRaw[]): {
         url: m.media_url_https,
         alt_text: m.ext_alt_text,
       });
-    } else if (m.type === 'video' || m.type === 'animated_gif') {
+    } else if (m.type === 'video') {
       videos.push(parseVideo(m));
+    } else if (m.type === 'animated_gif') {
+      videos.push(parseGif(m));
     }
 
     const sensitive = m.ext_sensitive_media_warning;
@@ -39,6 +41,26 @@ export function parseMediaGroups(media: TimelineMediaExtendedRaw[]): {
   }
 
   return { sensitiveContent, photos, videos };
+}
+
+function parseGif(
+  m: NonNullableField<TimelineMediaExtendedRaw, 'id_str' | 'media_url_https'>,
+): Video {
+  const gif: Video = {
+    id: m.id_str,
+    preview: m.media_url_https,
+  };
+
+  const variants = m.video_info?.variants ?? [];
+
+  const url = variants.find((v) => v.content_type === 'video/mp4')?.url;
+
+  if (url) {
+    gif.preview = url;
+    gif.url = url;
+  }
+
+  return gif;
 }
 
 function parseVideo(

--- a/src/timeline-v1.ts
+++ b/src/timeline-v1.ts
@@ -32,6 +32,7 @@ export interface ExtSensitiveMediaWarningRaw {
 
 export interface VideoVariant {
   bitrate?: number;
+  content_type?: string;
   url?: string;
 }
 

--- a/src/tweets.test.ts
+++ b/src/tweets.test.ts
@@ -397,8 +397,12 @@ test('scraper can get liked tweets', async () => {
 test('scraper can get animated image as video', async () => {
   const scraper = await getScraper({ authMethod: 'anonymous' });
   const tweet = await scraper.getTweet('1947627689285673423');
+
+  const expectedURL = 'https://video.twimg.com/tweet_video/GwdbuOGX0AEuVrj.mp4';
+
   expect(tweet?.videos).toContainEqual({
     id: '1947626213477961729',
-    preview: 'https://video.twimg.com/tweet_video/GwdbuOGX0AEuVrj.mp4',
+    preview: expectedURL,
+    url: expectedURL,
   });
 });

--- a/src/tweets.test.ts
+++ b/src/tweets.test.ts
@@ -397,9 +397,8 @@ test('scraper can get liked tweets', async () => {
 test('scraper can get animated image as video', async () => {
   const scraper = await getScraper({ authMethod: 'anonymous' });
   const tweet = await scraper.getTweet('1947627689285673423');
-  console.log(tweet);
   expect(tweet?.videos).toContainEqual({
     id: '1947626213477961729',
-    preview: 'https://pbs.twimg.com/tweet_video_thumb/GwdbuOGX0AEuVrj.jpg',
+    preview: 'https://video.twimg.com/tweet_video/GwdbuOGX0AEuVrj.mp4',
   });
 });


### PR DESCRIPTION
This PR fixes the bug that causes the .mp4 to not be returned when a GIF is present in a tweet.

Added a [`parseGif`](https://github.com/Faareoh/twitter-scraper/blob/47ff38725d8e80a5628dc64233f996fac226f5d2/src/timeline-tweet-util.ts#L46) function in `timeline-tweet-utils`.
Updated the `VideoVariant` interface to add the [`content_type`](https://github.com/Faareoh/twitter-scraper/blob/47ff38725d8e80a5628dc64233f996fac226f5d2/src/timeline-v1.ts#L35) field.
Updated the [corresponding test](https://github.com/Faareoh/twitter-scraper/blob/47ff38725d8e80a5628dc64233f996fac226f5d2/src/tweets.test.ts#L397).