### PR TITLE
Suspended X account throw a specific error

### DIFF
--- a/src/profile.test.ts
+++ b/src/profile.test.ts
@@ -91,3 +91,10 @@ test('scraper can get profile by screen name', async () => {
   const scraper = await getScraper();
   await scraper.getProfile('GeminiApp');
 });
+
+test('scraper return error on suspended profile', async () => {
+  const scraper = await getScraper();
+  await expect(scraper.getProfile('elon')).rejects.toThrow(
+    'User is suspended.',
+  );
+});

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -120,6 +120,9 @@ export interface UserRaw {
   data: {
     user: {
       result: {
+        __typename?: string;
+        message?: string;
+        reason?: string;
         rest_id?: string;
         is_blue_verified?: boolean;
         legacy: LegacyUserRaw;
@@ -211,6 +214,13 @@ export async function getProfile(
   }
   const { result: user } = value.data.user;
   const { legacy } = user;
+
+  if (user.__typename === 'UserUnavailable' && user?.reason === 'Suspended') {
+    return {
+      success: false,
+      err: new Error('User is suspended.'),
+    };
+  }
 
   if (user.rest_id == null || user.rest_id.length === 0) {
     return {


### PR DESCRIPTION
This PR allows a specific error to be returned when [`getProfile`](https://github.com/Faareoh/twitter-scraper/blob/91d56f4fc1edc3bc52ead09a085c68438b1b79b4/src/profile.ts#L185) is used on a suspended profile.
- Add `__typename`, `message` and `reason` fields to [`UserRaw`](https://github.com/Faareoh/twitter-scraper/blob/91d56f4fc1edc3bc52ead09a085c68438b1b79b4/src/profile.ts#L119C18-L119C26) interface.
  